### PR TITLE
resovle the issue "Reading variables without loading entire Netcdf File."

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ mainClass in Compile := Some("org.dia.algorithms.mcc.MainNetcdfDFSMCC")
 
 resolvers ++= Seq(
   Resolver.mavenLocal,
-  Resolver.file("Local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
+  Resolver.file("Local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
+  "maven Repository" at "http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"
 )
 
 /**
@@ -57,7 +58,7 @@ libraryDependencies ++= Seq(
   "edu.ucar" % "opendap" % "2.2.2",
   "joda-time" % "joda-time" % "2.8.1",
   "com.joestelmach" % "natty" % "0.11",
-  "edu.ucar" % "netcdf" % "4.2.20"
+  "edu.ucar" % "cdm" % "4.6.0"
 )
 
 assemblyMergeStrategy in assembly := {
@@ -70,6 +71,7 @@ assemblyMergeStrategy in assembly := {
   case x if x.contains("org.eclipse") => MergeStrategy.first
   case x if x.contains("org.apache") => MergeStrategy.first
   case x if x.contains("org.slf4j") => MergeStrategy.first
+  case x if x.endsWith("reference.conf") => MergeStrategy.concat
   case PathList("com", "esotericsoftware", xs@_ *) => MergeStrategy.last // For Log$Logger.class
   case x => MergeStrategy.first
 }

--- a/src/main/java/org/dia/HDFSRandomAccessFile.java
+++ b/src/main/java/org/dia/HDFSRandomAccessFile.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package orq.dia;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import ucar.unidata.io.RandomAccessFile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+public class HDFSRandomAccessFile extends RandomAccessFile {
+
+    protected URI fsURI;
+    protected Path filePath;
+    protected FSDataInputStream hfile;
+    protected FileStatus fileStatus;
+
+    public HDFSRandomAccessFile(String fileSystemURI, String location) throws IOException {
+        this(fileSystemURI,location,defaultBufferSize);
+    }
+
+
+    public HDFSRandomAccessFile(String fileSystemURI,String location, int bufferSize) throws IOException {
+        super(bufferSize);
+        fsURI = URI.create(fileSystemURI);
+        filePath = new Path(location);
+        this.location = location;
+        if (debugLeaks) {
+            openFiles.add(location);
+        }
+
+        FileSystem fs = FileSystem.get(fsURI,new Configuration());
+        hfile = fs.open(filePath);
+
+        fileStatus = fs.getFileStatus(filePath);
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        super.close();
+        hfile.close();
+    }
+
+    public long getLastModified() {
+        return fileStatus.getModificationTime();
+    }
+
+    @Override
+    public long length() throws IOException {
+        return fileStatus.getLen();
+    }
+
+    @Override
+    protected int read_(long pos, byte[] b, int offset, int len) throws IOException {
+        int n = hfile.read(pos,b,offset,len);
+        return n;
+    }
+
+    @Override
+    public long readToByteChannel(WritableByteChannel dest, long offset, long nbytes) throws IOException {
+        long need = nbytes;
+        byte[] buf = new byte[4096];
+
+        hfile.seek(offset);
+        int count = 0;
+        while (need > 0 && count != -1) {
+            need -= count;
+            dest.write(ByteBuffer.wrap(buf,0,count));
+            count = hfile.read(buf,0,4096);
+        }
+        return nbytes - need;
+    }
+}
+

--- a/src/main/scala/org/dia/Utils/NetCDFUtils.scala
+++ b/src/main/scala/org/dia/Utils/NetCDFUtils.scala
@@ -18,7 +18,9 @@
 package org.dia.Utils
 
 import org.slf4j.Logger
+import orq.dia.HDFSRandomAccessFile
 import ucar.ma2
+import ucar.nc2.NetcdfFile
 import ucar.nc2.dataset.NetcdfDataset
 
 import scala.language.implicitConversions
@@ -118,6 +120,25 @@ object NetCDFUtils {
       case e: java.io.IOException => LOG.error("Couldn't open dataset %s".format(url))
         null
       case ex: Exception => LOG.error("Something went wrong while reading %s".format(url))
+        null
+    }
+  }
+
+  /**
+    * Loads a NetCDF Dataset from HDFS
+    * @param dfsUri   HDFS URI(eg. hdfs://master:9000/)
+    * @param location file path on hdfs
+    * @param bufferSize the size of buffer to be used
+    */
+  def loadDFSNetCDFDataSet(dfsUri:String,location:String,bufferSize:Int):NetcdfDataset = {
+    NetcdfDataset.setUseNaNs(false)
+    try{
+      val raf = new HDFSRandomAccessFile(dfsUri,location,bufferSize)
+      new NetcdfDataset(NetcdfFile.open(raf,location,null,null))
+    } catch {
+      case e: java.io.IOException => LOG.error("Couldn't open dataset %s%s".format(dfsUri,location))
+        null
+      case ex: Exception => LOG.error("Something went wrong while reading %s%s".format(dfsUri,location))
         null
     }
   }


### PR DESCRIPTION
By using the feature in the commits,we are able to read netcdf file on HDFS like on local filesystem(only load necessary bytes).As with the demo code, we can process one big netcdf file in spark cluster(different spark node to process different variable or time data in the netcdf file). Finally, forgive me my poor English.

```
def main(args:Array[String]): Unit ={

  val scConf = new SparkConf().setAppName("hdfs nc").setMaster("local[3]")
  val sc = new SparkContext(scConf)

  val fsUri = "hdfs://master:9000"
  val hdfsFile = "/netcdf/HS_H08_20151130_0000_B01_FLDK_R10_S0110.nc"

  val nc = NetCDFUtils.loadDFSNetCDFDataSet(fsUri,hdfsFile,10000)

  val variables = nc.getVariables.map(_.getFullName)
  val varRDD = sc.parallelize(variables,3)

  val varSize = varRDD.map(v => {
    val nc = NetCDFUtils.loadDFSNetCDFDataSet(fsUri,hdfsFile,10000000)
    val variable = nc.findVariable(v)

    //do some process
    (v,variable.read().getSize)
  }).collect()

  varSize.foreach(vs => {
    println("variable name:"+vs._1+"\tsize:"+vs._2)
  })
}
```
