### PR TITLE
build for scala_2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 import sbt.Resolver
 
-assemblyJarName in assembly := "SciSparkTestExperiments.jar"
+assemblyJarName in assembly := "SciSpark.jar"
 
 name := "SciSparkTestExperiments"
 
 version := "1.0"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.10.5"
 
 scalacOptions := Seq("-feature", "-deprecation")
 
@@ -44,23 +44,23 @@ test in assembly := {}
 classpathTypes += "maven-plugin"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" % "scalatest_2.11" % "3.0.0-M14",
-  "org.apache.spark" % "spark-core_2.11" % "1.6.0" exclude("org.slf4j", "slf4j-api"),
-  "org.apache.spark" % "spark-mllib_2.11" % "1.6.0",
+  "org.scalatest" % "scalatest_2.10" % "3.0.0-M15",
+  "org.apache.spark" % "spark-core_2.10" % "1.6.0" exclude("org.slf4j", "slf4j-api"),
+  "org.apache.spark" % "spark-mllib_2.10" % "1.6.0",
   //Math Libraries
   //"org.jblas" % "jblas" % "1.2.3",
   // other dependencies here
-  "org.scalanlp" % "breeze_2.11" % "0.11.2",
-  "org.json4s" % "json4s-native_2.11" % "3.3.0",
+  "org.scalanlp" %% "breeze" % "0.11.2",
+  "org.json4s" %% "json4s-native" % "3.2.11",
   // native libraries greatly improve performance, but increase jar sizes.
-  "org.scalanlp" % "breeze-natives_2.11" % "0.11.2",
+  "org.scalanlp" %% "breeze-natives" % "0.11.2",
   // Nd4j scala api with netlib-blas backend
-  "org.nd4j" % "nd4s_2.11" % "0.4-rc3.8",
+  "org.nd4j" % "nd4s_2.10" % "0.4-rc3.8",
   "org.nd4j" % "nd4j-x86" % "0.4-rc3.8",
   "edu.ucar" % "opendap" % "2.2.2",
-  "joda-time" % "joda-time" % "2.9.1",
+  "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.8.1",
-  "com.joestelmach" % "natty" % "0.12",
+  "com.joestelmach" % "natty" % "0.11",
   "edu.ucar" % "cdm" % "4.6.0"
 )
 


### PR DESCRIPTION
The PR is start this process of building for scala_2.10.

Currently, the build will complete successfully and build the org.dia lib. 
- Running a jar created for the MCC algorithm will work
- Running a jar created for the PDF clustering will not work (runtime errors associated with scala v11) 

Next step on related to this PR is to downgrade the scala used in the PDF clustering code to work scala_2.10 ie. the file https://github.com/SciSpark/SciSpark/blob/master/src/main/scala/org/dia/algorithms/pdfclustering/MainCompute.scala
