### PR TITLE
Scispark 44- adding the relational operators to sciTensor operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ val sumAllRDD = reshapedRDD.reduce(_ + _)
 println(sumAllRDD)
 ```
 
+#Running the test
+```
+sbt
+```
+
+To run all the test use at the sbt prompt:
+```
+test
+```
+
+To run individual test use a command such as:
+```
+test-only org.dia.tensors.BasicTensorTest
+```
+
+
 #Grab em' Tag em' Graph em' : An Automated Search for Mesoscale Convective Complexes
 
 [GTG](http://static1.squarespace.com/static/538b31b5e4b02d5bb7053eba/t/53ea7f48e4b00015c3fcc5d3/1407876936029/KDW_ThesisFinal.pdf) is an algorithm designed to search for Mesoscale Convective Complexes given temperature brightness data.

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -129,15 +129,16 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
 
 /**
    * Masks the current variable array by preserving values
-   * equal to num.
-   */
-  def :==(num: Double): SciTensor = variables(varInUse) :== num
-
-/**
-   * Masks the current variable array by preserving values
    * not equal to num.
    */
   def !=(num: Double): SciTensor = variables(varInUse) != num
+
+/**
+   * Masks the current variable array by preserving values
+   * equal to num.
+   */
+  def :=(num: Double): SciTensor = variables(varInUse) := num
+
 
 
   /**

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -131,7 +131,7 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    * Masks the current variable array by preserving values
    * equal to num.
    */
-  def ==(num: Double): SciTensor = variables(varInUse) == num
+  def :==(num: Double): SciTensor = variables(varInUse) :== num
 
 /**
    * Masks the current variable array by preserving values

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -109,6 +109,37 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    */
   def <=(num: Double): SciTensor = variables(varInUse) <= num
 
+/**
+   * Masks the current variable array by preserving values
+   * greater than or equal to num.
+   */
+  def >=(num: Double): SciTensor = variables(varInUse) >= num
+
+/**
+   * Masks the current variable array by preserving values
+   * less than to num.
+   */
+  def <(num: Double): SciTensor = variables(varInUse) < num
+
+/**
+   * Masks the current variable array by preserving values
+   * greater than num.
+   */
+  def >(num: Double): SciTensor = variables(varInUse) > num
+
+/**
+   * Masks the current variable array by preserving values
+   * equal to num.
+   */
+  def ==(num: Double): SciTensor = variables(varInUse) == num
+
+/**
+   * Masks the current variable array by preserving values
+   * not equal to num.
+   */
+  def !=(num: Double): SciTensor = variables(varInUse) != num
+
+
   /**
    * Returns a block averaged tensor where the blocks are squares with
    * dimensions blockInt.

--- a/src/main/scala/org/dia/loaders/TestMatrixReader.scala
+++ b/src/main/scala/org/dia/loaders/TestMatrixReader.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.loaders
+
+import java.util.Random
+import org.nd4j.linalg.factory.Nd4j
+
+/**
+ * Generates random matrices.
+ */
+object TestMatrixReader {
+
+  def loadTestArray(uri: String, varname: String) = {
+    val sample = Array(
+    Array(240.0, 241.0, 240.0, 241.0, 241.0),
+    Array(230.0, 231.0, 240.0, 222.0, 241.0),
+    Array(242.0, 243.0, 244.0, 241.0, 232.0),
+    Array(240.0, 241.0, 230.0, 231.0, 241.0),
+    Array(240.0, 241.0, 240.0, 242.0, 241.0),
+    Array(242.0, 243.0, 244.0, 241.0, 242.0))
+
+    val sampleArray = Nd4j.create(sample)
+
+    (sampleArray.data.asDouble, sampleArray.shape)
+  }
+
+}

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -47,8 +47,13 @@ trait AbstractTensor extends Serializable with SliceableArray {
    * Masking operations
    */
 
+  def <(num: Double): T
+  def >(num: Double): T
   def <=(num: Double): T
+  def >=(num: Double): T
   def :=(num: Double): T
+  def !=(num: Double): T
+  
 
   /**
    * Utility Methods

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -69,10 +69,18 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
   def /(array: AbstractTensor) = tensor / array.tensor
 
   def *(array: AbstractTensor) = tensor :* array.tensor
+  
+  def <(num: Double) = tensor.map(v => if (v < num) v else 0.0)
+  
+  def >(num: Double) = tensor.map(v => if (v > num) v else 0.0)
 
   def <=(num: Double) = tensor.map(v => if (v <= num) v else 0.0)
 
+  def >=(num: Double) = tensor.map(v => if (v >= num) v else 0.0)
+
   def :=(num: Double) = tensor.map(v => if (v == num) v else 0.0)
+
+  def !=(num: Double) = tensor.map(v => if (v != num) v else 0.0)
 
   /**
    * Linear Algebra Operations

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -58,9 +58,18 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
    * Masking operations
    */
 
-  def <=(num: Double): Nd4jTensor = new Nd4jTensor(tensor.map(p => if (p < num) p else 0.0))
+  def <(num: Double): Nd4jTensor = new Nd4jTensor(tensor.map(p => if (p < num) p else 0.0))
 
-  def :=(num: Double) = new Nd4jTensor(tensor.map(p => if (p == num) p else 0.0))
+  def >(num: Double): Nd4jTensor = new Nd4jTensor(tensor.map(p => if (p > num) p else 0.0))
+
+  def <=(num: Double): Nd4jTensor = new Nd4jTensor(tensor.map(p => if (p <= num) p else 0.0))
+
+  def >=(num: Double): Nd4jTensor = new Nd4jTensor(tensor.map(p => if (p >= num) p else 0.0))
+
+  def :=(num: Double): Nd4jTensor = new Nd4jTensor(tensor.map(p => if (p == num) p else 0.0))
+
+  def !=(num: Double): Nd4jTensor = new Nd4jTensor(tensor.map(p => if (p != num) p else 0.0))
+
 
   /**
    * Linear Algebra Operations

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -17,23 +17,141 @@
  */
 package org.dia.tensors
 
+import org.dia.core.{ SRDD, SciTensor }
 import org.nd4j.linalg.factory.Nd4j
 import org.scalatest.FunSuite
 import org.nd4s.Implicits._
+import org.dia.loaders.TestMatrixReader._
+import org.dia.partitioners.SPartitioner._
+import org.dia.testenv.SparkTestConstants
 
 /**
  * Tests basic tensor functionality.
  */
 class BasicTensorTest extends FunSuite {
 
+  val fakeURI = List("0000010100")
+  val varName = List("randVar")
+  val st = SparkTestConstants.sc.sparkContext
+  val sRDD = new SRDD[SciTensor](st, fakeURI, varName, loadTestArray, mapOneUrl)
+
+  /**
+  * Test relational operators
+  **/
+
   test("filter") {
+    println("In filter test ...")
     val dense = Nd4j.create(Array[Double](1, 241, 241, 1), Array(2, 2))
     val t = dense.map(p => if (p < 241.0) p else 0.0)
     println(t)
     assert(true)
   }
 
+ test("filterLessThan") {
+    println("In filterLessThan test ...")
+    val t = sRDD.map(p => p("randVar") < 241.0)
+    println("The sciTensor is: "+ t.collect().toList)
+    println("The values are: "+ t.collect().toList(0).variables.values.toList)
+    val tVals = t.collect().toList(0).variables.values.toList(0).toString.split("  ").toList.filter(_!="")
+    val count = tVals.filter(_.toDouble < 241.0).length - tVals.filter(_.toDouble == 0.0).length
+    println(count + " are less than 241.0")  
+
+    if (count == 12){
+      assert(true)
+      }else{
+        assert(false)
+      }   
+  }
+
+  test("filterLessThanEquals") {
+    println("In filterLessThanEquals test ...")
+    val t = sRDD.map(p => p("randVar") <= 241.0)
+    println("The sciTensor is: "+ t.collect().toList)
+    println("The values are: "+ t.collect().toList(0).variables.values.toList)
+    val tVals = t.collect().toList(0).variables.values.toList(0).toString.split("  ").toList.filter(_!="")
+    val count = tVals.filter(_.toDouble != 0.0).length //- tVals.filter(_.toDouble == 0.0).length
+    println(count + " are less than or equals to 241.0")  
+     
+    if (count == 22){
+      assert(true)
+      }else{
+        assert(false)
+      }   
+  }
+
+  test("filterGreaterThan") {
+    println("In filterGreaterThan test ...")
+    val t = sRDD.map(p => p("randVar") > 241.0)
+    println("The sciTensor is: "+ t.collect().toList)
+    println("The values are: "+ t.collect().toList(0).variables.values.toList)
+    val tVals = t.collect().toList(0).variables.values.toList(0).toString.split("  ").toList.filter(_!="")
+    val count = tVals.filter(_.toDouble != 0.0).length 
+    println(count + " are greater than 241.0")  
+     
+    if (count == 8){
+      assert(true)
+      }else{
+        assert(false)
+      }   
+  }
+
+  test("filterGreaterThanEquals") {
+    println("In filterGreaterThanEquals test ...")
+    val t = sRDD.map(p => p("randVar") >= 241.0)
+    println("The sciTensor is: "+ t.collect().toList)
+    println("The values are: "+ t.collect().toList(0).variables.values.toList)
+    val tVals = t.collect().toList(0).variables.values.toList(0).toString.split("  ").toList.filter(_!="")
+    val count = tVals.filter(_.toDouble != 0.0).length 
+    println(count + " are greater than or equals to 241.0")  
+     
+    if (count == 18){
+      assert(true)
+      }else{
+        assert(false)
+      }   
+  }
+
+  test("filterEquals") {
+    println("In filterLessThan test ...")
+    val t = sRDD.map(p => p("randVar") := 241.0)
+    println("The sciTensor is: "+ t.collect().toList)
+    println("The values are: "+ t.collect().toList(0).variables.values.toList)
+    val tVals = t.collect().toList(0).variables.values.toList(0).toString.split("  ").toList.filter(_!="")
+    val count = tVals.filter(_.toDouble != 0.0).length 
+    println(count + " are equal to 241.0")  
+     
+    if (count == 10){
+      assert(true)
+      }else{
+        assert(false)
+      }   
+  }
+
+  test("filterNotEquals") {
+    println("In filterNotEquals test ...")
+    val t = sRDD.map(p => p("randVar") != 241.0)
+    println("The sciTensor is: "+ t.collect().toList)
+    println("The values are: "+ t.collect().toList(0).variables.values.toList)
+    val tVals = t.collect().toList(0).variables.values.toList(0).toString.split("  ").toList.filter(_!="")
+    val count = tVals.filter(_.toDouble  != 0.0).length 
+    println(count + " are not equals to 241.0")  
+     
+    if (count == 20){
+      assert(true)
+      }else{
+        assert(false)
+      }   
+  }
+
+  /**
+  * End Test relational operators
+  **/
+  
+  /**
+  * Test slicing
+  **/
   test("Nd4sSlice") {
+    println("In Nd4sSlice test ...")
     val nd = Nd4j.create((0d to 8d by 1d).toArray, Array(4, 2))
     println(nd)
     println(nd(0 -> 1, ->))

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -146,7 +146,7 @@ class BasicTensorTest extends FunSuite {
   /**
   * End Test relational operators
   **/
-  
+
   /**
   * Test slicing
   **/
@@ -154,8 +154,9 @@ class BasicTensorTest extends FunSuite {
     println("In Nd4sSlice test ...")
     val nd = Nd4j.create((0d to 8d by 1d).toArray, Array(4, 2))
     println(nd)
+    println("slicing")
     println(nd(0 -> 1, ->))
-    assert(false)
+    assert(true)
   }
 
 }


### PR DESCRIPTION
Currently only <= and = were represented as operators for the sciTensor's abstractTensor. This PR adds
<,>,>=, and != as well. These will be useful for masking out functionality. 
