### PR TITLE
[SCISPARK #69][ESIP workshop] update opendap to 4.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   // Nd4j scala api with netlib-blas backend
   "org.nd4j" % "nd4s_2.10" % "0.4-rc3.8",
   "org.nd4j" % "nd4j-x86" % "0.4-rc3.8",
-  "edu.ucar" % "opendap" % "2.2.2",
+  "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.8.1",
   "com.joestelmach" % "natty" % "0.11",


### PR DESCRIPTION
We update the opendap dependency to 4.6.0, to be in line with the netcdf version.
We initially tried updating to 4.6.6 on both netcdf and opendap but this creates a http dependency conflict
which triggered the error mentioned in Issue #69.
