### PR TITLE
[SCISPARK 72][ESIP Workshop] reshaping arrays

### DIFF
--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -50,7 +50,7 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   /**
    * Reshapes the variable in use
    */
-  def reshape(reshapedVarName : String, shape : Array[Int]) : SciTensor = {
+  def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))
     this
   }

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -48,6 +48,14 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   }
 
   /**
+   * Reshapes the variable in use
+   */
+  def reshape(reshapedVarName : String, shape : Array[Int]) : SciTensor = {
+    insertVar(reshapedVarName, variables(varInUse).reshape(shape))
+    this
+  }
+
+  /**
    * Writes metaData in the form of key-value pairs
    */
   def insertDictionary(metaDataVar: (String, String)*): Unit = {

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -55,7 +55,7 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    * @param reshapedVarName The new variable name. Default is the current variable in use.
    * @param shape The array specifying dimensions of the new shape
    */
-  def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
+  def reshape(shape : Array[Int], reshapedVarName : String = varInUse) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))
     this
   }

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -52,8 +52,8 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    * If a new name is not specified then the variable in use is used by default.
    * The AbstractTensor which corresponds to the variable in use is replaced by
    * the reshaped one.
-   * @param reshapedVarName the new variable name. Default is the current variable in use
-   * @param shape the array specifying dimensions of the new shape
+   * @param reshapedVarName The new variable name. Default is the current variable in use.
+   * @param shape The array specifying dimensions of the new shape
    */
   def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -48,7 +48,11 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   }
 
   /**
-   * Reshapes the variable in use
+   * Reshapes the array and inserts the reshaped array into the variable hashmap.
+   * If a new name is not specified then the variable in use is used by default.
+   * The AbstractTensor which corresponds to the variable in use is replaced by
+   * the reshaped one.
+   *
    */
   def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -52,7 +52,8 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
    * If a new name is not specified then the variable in use is used by default.
    * The AbstractTensor which corresponds to the variable in use is replaced by
    * the reshaped one.
-   *
+   * @param reshapedVarName the new variable name. Default is the current variable in use
+   * @param shape the array specifying dimensions of the new shape
    */
   def reshape(reshapedVarName : String = varInUse, shape : Array[Int]) : SciTensor = {
     insertVar(reshapedVarName, variables(varInUse).reshape(shape))

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -11,6 +11,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
   val name: String
   val LOG = org.slf4j.LoggerFactory.getLogger(this.getClass)
 
+  def reshape(shape: Array[Int]): T
   def zeros(shape: Int*): T
 
   def map(f: Double => Double): AbstractTensor

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -47,6 +47,9 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
     this(loadFunc())
   }
 
+  def reshape(shape: Array[Int]) = {
+    new BreezeTensor((this.data, shape))
+  }
   /**
    * Constructs a zeroed BreezeTensor.
    *
@@ -114,7 +117,7 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
 
   def div(num: Double): BreezeTensor = tensor / num
 
-  def data = tensor.t.toArray
+  def data : Array[Double] = tensor.t.toArray
 
   /**
    * SlicableArray operations

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -38,6 +38,8 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
     this(loadFunc())
   }
 
+  def reshape(shape: Array[Int]) = new Nd4jTensor(Nd4j.create(this.data, shape))
+
   def zeros(shape: Int*) = new Nd4jTensor(Nd4j.create(shape: _*))
 
   def map(f: Double => Double) = new Nd4jTensor(tensor.map(p => f(p)))
@@ -117,7 +119,7 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
   def apply(indexes: Int*) = tensor.get(indexes.toArray)
 
-  def data = tensor.data.asDouble()
+  def data : Array[Double] = tensor.data.asDouble()
 
   /**
    * Utility Functions

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -43,6 +43,15 @@ class BasicTensorTest extends FunSuite {
   * Test relational operators
   **/
 
+  test("reshape") {
+    logger.info("In reshape test ...")
+    val cube = Nd4j.create((1d to 16d by 1d).toArray, Array(2,2,2,2))
+    val square = Nd4j.create((1d to 16d by 1d).toArray, Array(4,4))
+    val cubeTensor = new Nd4jTensor(cube)
+    val squareTensor = new Nd4jTensor(square)
+    val reshapedcubeTensor = cubeTensor.reshape(Array(4,4))
+    assert(reshapedcubeTensor == squareTensor)
+  }
   test("filter") {
     logger.info("In filter test ...")
     val dense = Nd4j.create(Array[Double](1, 241, 241, 1), Array(2, 2))
@@ -441,7 +450,7 @@ class BasicTensorTest extends FunSuite {
     val tdefault = sRDD.map(p => (p.data, p.shape))
     val varDataDef = tdefault.collect()(0)
     logger.info("The varInUse default data is: "+ varDataDef._1.mkString(" ") + "\nShape: (" + varDataDef._2.mkString(" , ")+")")
-    
+
     if (!(varData._1.sameElements(varData1._1)) && (varData1._1.sameElements(varDataDef._1))){
       assert(true)
     }else{


### PR DESCRIPTION
In order to address issue #72 this PR makes the following changes to SciTensor,
AbstractTensor and it's implementing classes.
1. When calling reshape from SciTensor, if a new variable name is not specified
   then the reshaped variable is used to replace the original value under the same ke
   in the variables hashmap. If a new variable name is specified (and it is different from
   the variable in use) then a new (key, AbstractTensor) entry will be made into the hashmap.
2. While SciTensor handles the metadata associated with the individual array (in this case the naming), 
   it delegates to the AbstractTensor's reshape method for the actual reshaping of the array.

The test for this new function can be found [here](https://github.com/rahulpalamuttam/SciSpark/blob/reshaping/src/test/scala/org/dia/tensors/BasicTensorTest.scala#L46-L54):
