### PR TITLE
[SCISPARK 68] SciTensor api changes

### DIFF
--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -77,6 +77,15 @@ class SciTensor(val variables: mutable.HashMap[String, AbstractTensor]) extends 
   }
 
   /**
+   * Returns the array corresponding to the variable in use.
+   * This is to mimic the numpy like syntax of nc['var'][:]
+   * Example usage: val absT = sciT('var')()
+   * @return AbstractTensor corresponding to variable in use
+   */
+  def apply(): AbstractTensor = variables(varInUse)
+
+
+  /**
    * Slices the head variable array given the list of ranges per dimension.
    */
   def apply(ranges: (Int, Int)*): SciTensor = {

--- a/src/main/scala/org/dia/core/Variable.scala
+++ b/src/main/scala/org/dia/core/Variable.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.core
+
+import java.io.Serializable
+import org.dia.tensors.AbstractTensor
+import org.dia.utils.NetCDFUtils
+import ucar.nc2.Attribute
+import scala.collection.{TraversableOnce, mutable}
+
+class Variable(val name : String,
+               val numericType : String,
+               val array : AbstractTensor,
+               val attributes : mutable.HashMap[String, String]) extends Serializable {
+
+  val LOG = org.slf4j.LoggerFactory.getLogger(this.getClass)
+
+  def this(name: String, numericType: String, array : AbstractTensor, attr : TraversableOnce[(String, String)]){
+    this(name, numericType, array, new mutable.HashMap[String, String] ++= attr)
+  }
+
+  def this(name: String, numericType: String, array : AbstractTensor, attr : Array[Attribute]){
+    this(name, numericType, array, attr.map(p => NetCDFUtils.convertAttribute(p)))
+  }
+
+  def this(name: String, numericType: String, array : AbstractTensor, attr : java.util.List[Attribute]){
+    this(name, numericType, array, attr.toArray.map(p => p.asInstanceOf[Attribute]))
+  }
+
+  def this(name: String, array : AbstractTensor){
+    this(name, "Double64", array, new mutable.HashMap[String, String])
+  }
+
+  def this(array : AbstractTensor) {
+    this("unnamed", array)
+  }
+
+  /**
+   * Writes attribute in the form of key-value pairs
+   */
+  def insertAttributes(metaDataVar: (String, String)*): Unit = {
+    for (variable <- metaDataVar) attributes += variable
+  }
+
+  def insertAttributes(metaDataVars: TraversableOnce[(String, String)]): Unit = {
+    attributes ++= metaDataVars
+  }
+
+  /**
+   * Returns the array corresponding to the variable in use.
+   * This is to mimic the numpy like syntax of var[:]
+   * Example usage: val absT = var()
+   * @return AbstractTensor corresponding to variable in use
+   */
+  def apply(): AbstractTensor = array
+
+  /**
+   * Access attribute values.
+   * In Python's netcdf variable, attributes can be accessed as
+   * members of classes like so:
+   *    variable.attribute1
+   * In scala we can't do that so we access attributes with the
+   * apply function like so:
+   *    variable("attribute")
+   *
+   * @param key the attribute name
+   * @return the attribute value
+   */
+  def apply(key : String) : String = attributes(key)
+
+  def shape(): Array[Int] = array.shape
+  def data() : Array[Double] = array.data
+
+  /**
+   * Creates a copy of the variable
+   * @return
+   */
+  def copy() : Variable = new Variable(name, numericType, array.copy, attributes.clone())
+
+  /**
+   * It should print just the same or similar to how
+   * variables are printed in Netcdf python.
+   * e.g.
+   *
+   * float32 ch4(time, latitude, longitude)
+   *    comments: Unknown1 variable comment
+   *    long_name: IR BT (add 75 to this value)
+   *    units:
+   *    grid_name: grid01
+   *    grid_type: linear
+   *    level_description: Earth surface
+   *    time_statistic: instantaneous
+   *    missing_value: 330.0
+   * current shape = (1238, 4125)
+   *
+   */
+  override def toString: String = {
+    val header = numericType + " " + name + "\n"
+    val footer = "current shape = " + shape().toList + "\n"
+    val body = new StringBuilder()
+    body.append(header)
+    for((k,v) <- attributes){
+      body.append("\t" + k + ": " + v + "\n" )
+    }
+    body.append(footer.replace("List", ""))
+    body.toString()
+  }
+
+  override def equals(any: Any) : Boolean = {
+    val variable = any.asInstanceOf[Variable]
+    this.name == variable.name &&
+      this.numericType == variable.numericType &&
+      this.array == variable.array &&
+      this.attributes == variable.attributes
+  }
+
+}
+

--- a/src/main/scala/org/dia/utils/NetCDFUtils.scala
+++ b/src/main/scala/org/dia/utils/NetCDFUtils.scala
@@ -20,7 +20,8 @@ package org.dia.utils
 import org.slf4j.Logger
 import org.dia.HDFSRandomAccessFile
 import ucar.ma2
-import ucar.nc2.NetcdfFile
+import ucar.ma2.DataType
+import ucar.nc2.{Attribute, NetcdfFile}
 import ucar.nc2.dataset.NetcdfDataset
 import scala.language.implicitConversions
 
@@ -29,7 +30,7 @@ import scala.language.implicitConversions
  *
  * Note that we use -9999.0 instead of NaN to indicate missing values.
  */
-object NetCDFUtils {
+object NetCDFUtils extends Serializable {
 
   // Class logger
   val LOG = org.slf4j.LoggerFactory.getLogger(this.getClass)
@@ -161,6 +162,25 @@ object NetCDFUtils {
     if (dimSize < 0)
       throw new IllegalStateException("Dimension does not exist!!!")
     dimSize
+  }
+
+  /**
+   * Given an attribute, converts it into a
+   * key value String pair.
+   * The attribute data type is checked.
+   * If it is not a string then it is number and
+   * is converted to a String.
+   *
+   * @param attribute the netCDF attribute
+   * @return (attribute name, attribute value)
+   */
+  def convertAttribute(attribute: Attribute) : (String, String) = {
+    val key = attribute.getFullName
+    val value = attribute.getDataType match {
+      case DataType.STRING => attribute.getStringValue
+      case _               => attribute.getNumericValue().toString
+    }
+    (key, value)
   }
 
 }

--- a/src/main/scala/org/dia/utils/NetCDFUtils.scala
+++ b/src/main/scala/org/dia/utils/NetCDFUtils.scala
@@ -21,7 +21,7 @@ import org.slf4j.Logger
 import org.dia.HDFSRandomAccessFile
 import ucar.ma2
 import ucar.ma2.DataType
-import ucar.nc2.{Attribute, NetcdfFile}
+import ucar.nc2.{Variable, Attribute, NetcdfFile}
 import ucar.nc2.dataset.NetcdfDataset
 import scala.language.implicitConversions
 
@@ -181,6 +181,25 @@ object NetCDFUtils extends Serializable {
       case _               => attribute.getNumericValue().toString
     }
     (key, value)
+  }
+
+  /**
+   * Extracts the flattened double array from a netCDF Variable
+   * @param variable the netCDF variable
+   * @return the flattened Double Array
+   */
+  def getArrayFromVariable(variable: Variable): Array[Double] = {
+    var searchVariable : ma2.Array = null
+    if (variable == null) throw new IllegalStateException("Variable '%s' was not loaded".format(variable))
+    try {
+      searchVariable = variable.read()
+    } catch {
+      case ex: Exception =>
+        LOG.error("Variable '%s' not found when reading source %s.".format(variable))
+        LOG.info("Variables available: " + variable)
+        LOG.error(ex.getMessage)
+    }
+    convertMa2Arrayto1DJavaArray(searchVariable)
   }
 
 }

--- a/src/test/scala/org/dia/core/VariableTest.scala
+++ b/src/test/scala/org/dia/core/VariableTest.scala
@@ -29,11 +29,9 @@ class VariableTest extends FunSuite {
 
   val (array, shape) = NetCDFUtils.netCDFArrayAndShape(netcdfDataset, name)
   val dataVar = netcdfDataset.findVariable(name)
-  val dataType = dataVar.getDataType.toString
-  val attributes = dataVar.getAttributes
 
   val tensor = new Nd4jTensor(array, shape)
-  val variable = new Variable(name, dataType, tensor, attributes)
+  val variable = new Variable(dataVar)
 
 
   test("testCopy") {

--- a/src/test/scala/org/dia/core/VariableTest.scala
+++ b/src/test/scala/org/dia/core/VariableTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.core
+
+import org.dia.tensors.Nd4jTensor
+import org.dia.utils.NetCDFUtils
+import org.scalatest.FunSuite
+
+class VariableTest extends FunSuite {
+
+
+  val netcdfDataset = NetCDFUtils.loadNetCDFDataSet("resources/merg/merg_2006091100_4km-pixel.nc")
+  val name = "ch4"
+
+  val (array, shape) = NetCDFUtils.netCDFArrayAndShape(netcdfDataset, name)
+  val dataVar = netcdfDataset.findVariable(name)
+  val dataType = dataVar.getDataType.toString
+  val attributes = dataVar.getAttributes
+
+  val tensor = new Nd4jTensor(array, shape)
+  val variable = new Variable(name, dataType, tensor, attributes)
+
+
+  test("testCopy") {
+    val copy = variable.copy()
+    assert(copy == variable)
+  }
+
+  test("testAttributesApply") {
+    val gridTypeAttribute = variable("grid_type")
+    assert(gridTypeAttribute == "linear")
+  }
+
+  test("testApply") {
+    val tensorCopy = tensor.copy
+    val origTensor = variable()
+    assert(tensor == origTensor)
+  }
+
+  test("testInsertAttributes") {
+    variable.insertAttributes(("random_attribute", "value1"))
+    val insertedAttribute = variable("random_attribute")
+    assert(insertedAttribute == "value1")
+  }
+
+  test("testShape") {
+    val shape = variable.shape()
+    assert(shape.toList == List(1238, 4125))
+  }
+
+  test("testData") {
+    val shapeProduct = variable.shape().product
+    val array = variable.data()
+    assert(array.length == shapeProduct)
+    assert(array.deep == this.array.deep)
+  }
+
+  test("testToString") {
+    val string = "float ch4\n" +
+                "\trandom_attribute: value1\n" +
+                "\tlevel_description: Earth surface\n" +
+                "\tgrid_type: linear\n" +
+                "\tmissing_value: 330.0\n" +
+                "\tunits: \n" +
+                "\tlong_name: IR BT (add 75 to this value)\n" +
+                "\tgrid_name: grid01\n" +
+                "\tcomments: Unknown1 variable comment\n" +
+                "\ttime_statistic: instantaneous\n" +
+                "current shape = (1238, 4125)\n"
+    assert(variable.toString == string)
+  }
+
+}

--- a/src/test/scala/org/dia/tensors/SciTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/SciTensorTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.tensors
+
+import org.dia.core.SciTensor
+import org.nd4j.linalg.factory.Nd4j
+import org.scalatest.FunSuite
+
+class SciTensorTest extends FunSuite {
+
+  test("ApplyNullary") {
+    val square = Nd4j.create((0 to 9).toArray, Array(3,3))
+    val absT = new Nd4jTensor(square)
+    val absTCopy = absT.copy
+    val sciT = new SciTensor("sample", absT)
+    val extracted = sciT("sample")()
+    assert(extracted.isInstanceOf[org.dia.tensors.AbstractTensor])
+    assert(extracted == absTCopy)
+  }
+}


### PR DESCRIPTION
This PR will be mostly a work in progress.
I just wanted to put it in right now and continue committing to it.
Right now all the PR does is have another apply function on SciTensor
that takes no parameters, and returns the underlying array (in a Python NetcdfDataset way).

Future commits to the PR will address the changes proposed in issue #68 and issue #51.
The PR will also reflect changes with respect to our ongoing discussion on
SciTensor.
