### PR TITLE
[SCISPARK 32] Continuously Integrate SciSpark code with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# SciSpark provides this Travis CI configuration file to help contributors
+# check build and test results for their pull requests
+
+# 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
+sudo: required
+dist: trusty
+
+# 2. Choose language and target JDKs for parallel  builds
+language: scala
+scala:
+  - 2.10.6
+
+# 3. Setup cache directory for SBT
+cache:
+  directories:
+  - $HOME/.sbt
+  - $HOME/.m2
+
+# 4. Turn off notifications
+notifications:
+  email: false
+
+# 5. Run maven sbt compile and sbt test
+install:
+  - sbt compile
+  - sbt test
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 SciSpark
 ====
 
+[![Build Status](https://travis-ci.org/rahulpalamuttam/SciSpark?branch=master)](https://travis-ci.org/rahulpalamuttam/SciSpark)
+
 ![picture alt](http://image.slidesharecdn.com/jljkdhlxtlgwcyboil6n-signature-c9af2d5a7f730d5a4779821a7bd1f0333657fd7c0430ac7965a5576c08924b8a-poli-150624001008-lva1-app6891/95/spark-at-nasajplchris-mattmann-nasajpl-29-638.jpg?cb=1435104721)
 #Update
 SciSpark can now read Netcdf files from HDFS using SciSparkContext.NetcdfDFSFile by leveraging the binaryFiles function.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SciSpark
 ====
 
-[![Build Status](https://travis-ci.org/rahulpalamuttam/SciSpark?branch=master)](https://travis-ci.org/rahulpalamuttam/SciSpark)
+[![Build Status](https://travis-ci.org/rahulpalamuttam/SciSpark.svg?branch=master)](https://travis-ci.org/rahulpalamuttam/SciSpark)
 
 ![picture alt](http://image.slidesharecdn.com/jljkdhlxtlgwcyboil6n-signature-c9af2d5a7f730d5a4779821a7bd1f0333657fd7c0430ac7965a5576c08924b8a-poli-150624001008-lva1-app6891/95/spark-at-nasajplchris-mattmann-nasajpl-29-638.jpg?cb=1435104721)
 #Update

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SciSpark
 ====
 
-[![Build Status](https://travis-ci.org/rahulpalamuttam/SciSpark.svg?branch=master)](https://travis-ci.org/rahulpalamuttam/SciSpark)
+[![Build Status](https://travis-ci.org/SciSpark/SciSpark.svg?branch=master)](https://travis-ci.org/SciSpark/SciSpark)
 
 ![picture alt](http://image.slidesharecdn.com/jljkdhlxtlgwcyboil6n-signature-c9af2d5a7f730d5a4779821a7bd1f0333657fd7c0430ac7965a5576c08924b8a-poli-150624001008-lva1-app6891/95/spark-at-nasajplchris-mattmann-nasajpl-29-638.jpg?cb=1435104721)
 #Update


### PR DESCRIPTION
Travis CI is an excellent tool for our purposes of continuous integration
and running tests. I have succesfully set it up and added the badge on my
own fork of SciSpark. The following PR assumes the SciSpark organization
on github has done the same.

I do not have member access to SciSpark and so cannot set up travis ci for it.
Can someone grant me member access, or sign in under the SciSpark github
organization here : https://travis-ci.com/
