### PR TITLE
[SCISPARK 5] Gitter Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 SciSpark
 ====
-[![Build Status](https://travis-ci.org/SciSpark/SciSpark.svg?branch=master)](https://travis-ci.org/SciSpark/SciSpark)
+
 [![Join the chat at https://gitter.im/scientificspark](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scientificspark/Lobby)
+
+[![Build Status](https://travis-ci.org/SciSpark/SciSpark.svg?branch=master)](https://travis-ci.org/SciSpark/SciSpark)
+
 ![picture alt](http://image.slidesharecdn.com/jljkdhlxtlgwcyboil6n-signature-c9af2d5a7f730d5a4779821a7bd1f0333657fd7c0430ac7965a5576c08924b8a-poli-150624001008-lva1-app6891/95/spark-at-nasajplchris-mattmann-nasajpl-29-638.jpg?cb=1435104721)
 #Update
 SciSpark can now read Netcdf files from HDFS using SciSparkContext.NetcdfDFSFile by leveraging the binaryFiles function.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 SciSpark
 ====
-
 [![Build Status](https://travis-ci.org/SciSpark/SciSpark.svg?branch=master)](https://travis-ci.org/SciSpark/SciSpark)
-
+[![Join the chat at https://gitter.im/scientificspark](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scientificspark/Lobby)
 ![picture alt](http://image.slidesharecdn.com/jljkdhlxtlgwcyboil6n-signature-c9af2d5a7f730d5a4779821a7bd1f0333657fd7c0430ac7965a5576c08924b8a-poli-150624001008-lva1-app6891/95/spark-at-nasajplchris-mattmann-nasajpl-29-638.jpg?cb=1435104721)
 #Update
 SciSpark can now read Netcdf files from HDFS using SciSparkContext.NetcdfDFSFile by leveraging the binaryFiles function.


### PR DESCRIPTION
The following points to the gitter community named scientificspark.
Right now it only points to the lobby.
I have requested access for the SciSpark project to create a SciSpark room.

I really wish I could have named the community scispark, but for some reason
gitter simply would not accept that name claiming it was already taken.
For anyone who wants to try making a gitter community with name "scispark" and see what you get.
