### PR TITLE
[SCISPARK 86] upgrade nd4j version, nd4j kryo, remove nd4s dependency, cleanup SRDDTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,16 +47,17 @@ libraryDependencies ++= Seq(
   "org.scalatest" % "scalatest_2.10" % "3.0.0-M15",
   "org.apache.spark" % "spark-core_2.10" % "1.6.0" exclude("org.slf4j", "slf4j-api"),
   "org.apache.spark" % "spark-mllib_2.10" % "1.6.0",
-  //Math Libraries
-  //"org.jblas" % "jblas" % "1.2.3",
+  // Math Libraries
+  // "org.jblas" % "jblas" % "1.2.3",
   // other dependencies here
   "org.scalanlp" %% "breeze" % "0.11.2",
   "org.json4s" %% "json4s-native" % "3.2.11",
   // native libraries greatly improve performance, but increase jar sizes.
   "org.scalanlp" %% "breeze-natives" % "0.11.2",
   // Nd4j scala api with netlib-blas backend
-  "org.nd4j" % "nd4s_2.10" % "0.4-rc3.8",
-  "org.nd4j" % "nd4j-x86" % "0.4-rc3.8",
+  // "org.nd4j" % "nd4s_2.10" % "0.5.0",
+  "org.nd4j" % "nd4j-native" % "0.5.0" classifier "" classifier "linux-x86_64",
+  "org.nd4j" % "nd4j-kryo_2.10" % "0.5.0",
   "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.8.1",

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -62,9 +62,16 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
   sparkContext.setLocalProperty(ARRAY_LIB, BREEZE_LIB)
 
 
+  /**
+   * We use kryo serialization.
+   * As of nd4j 0.5.0 we need to add the Nd4jRegistrar to avoid nd4j serialization errors.
+   * These errors come in the form of NullPointerErrors.
+   * @param conf Configuration for a spark application
+   */
   def this(conf: SparkConf) {
     this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryo.classesToRegister", "java.lang.Thread")
+      .set("spark.kryo.registrator", "org.nd4j.Nd4jRegistrator")
       .set("spark.kryoserializer.buffer.max", "256MB")))
   }
 
@@ -89,9 +96,9 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
    * Some datasets (like those hosted by gesdisc) require http credentials
    * for authentiation and access.
    *
-   * @param uri
-   * @param username
-   * @param password
+   * @param uri webpage url
+   * @param username the username used for authentication
+   * @param password the password used for authentication
    */
   def addHTTPCredential(uri: String, username: String, password: String): Unit = {
     HTTPCredentials = HTTPCredentials.+:((uri, username, password))

--- a/src/main/scala/org/dia/tensors/SliceableArray.scala
+++ b/src/main/scala/org/dia/tensors/SliceableArray.scala
@@ -24,9 +24,9 @@ trait SliceableArray {
 
   type T <: SliceableArray
 
-  def rows: Int
+  def rows(): Int
 
-  def cols: Int
+  def cols(): Int
 
   def shape: Array[Int]
 

--- a/src/test/scala/org/dia/tensors/SciTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/SciTensorTest.scala
@@ -25,7 +25,7 @@ import org.dia.core.SciTensor
 class SciTensorTest extends FunSuite {
 
   test("ApplyNullary") {
-    val square = Nd4j.create((0 to 9).toArray, Array(3, 3))
+    val square = Nd4j.create((0d to 9d by 1d).toArray, Array(3, 3))
     val absT = new Nd4jTensor(square)
     val absTCopy = absT.copy
     val sciT = new SciTensor("sample", absT)

--- a/src/test/scala/org/dia/tensors/perf/Nd4JPerformanceTest.scala
+++ b/src/test/scala/org/dia/tensors/perf/Nd4JPerformanceTest.scala
@@ -18,7 +18,6 @@
 package org.dia.tensors.perf
 
 import org.nd4j.linalg.factory.Nd4j
-import org.nd4s.Implicits._
 import org.scalatest.FunSuite
 
 /**
@@ -35,9 +34,9 @@ class Nd4JPerformanceTest extends FunSuite {
        * subtraction
        */
       val start = System.nanoTime()
-      val m3 = m1 - m2
+      val m3 = m1.sub(m2)
       val stop = System.nanoTime()
-      println((stop - start))
+      println(stop - start)
     }
     assert(true)
   }
@@ -51,7 +50,7 @@ class Nd4JPerformanceTest extends FunSuite {
        * element-wise multiplication
        */
       val start = System.nanoTime()
-      val m3 = m1 * m2
+      val m3 = m1.mul(m2)
       val stop = System.nanoTime()
       println(stop - start)
     }


### PR DESCRIPTION
The PR includes the following changes
It addresses issue #86 and #95 #81 

1.

Upgrading the nd4j version to 0.5.0.
A key point here is that nd4j now allocates it's arrays off-heap but still obeys the java heap parameters.
I've also included the nd4j kryoregistrator which means we shouldn't be running into serializability issues.
Since the arrays live off-heap - any serializability issues with nd4j will result in NPE's being thrown rather than a not-serializable exception. This shouldn't occur anyway since we added the kryoregistrator.

2.

I'm removing our dependency on nd4s, the scala wrapper for nd4j.
After having a brief discussion it seems several functions in nd4s is broken and the project
itself isn't a high priority for them. In any case I think it's best we define our own api calls in scala with Nd4jTensor. We just continue to leverage the nd4j library and define the simple +,-,*,/ operators.
This change didn't cause any code outside of Nd4jTensor and the performance tests to change.
I've left the dependency line commented out in build.sbt.
Please let me know if we should just delete it (and all the commented dependencies in general).

3.

SRDDTest has received a bit of an overhall as far as the tests go.
There were several tests that converted the underlying data into a string representation to do comparisons. This was unnecessary has been removed.
Some of the larger tests, like matrixDivision, had several sub-tests in it.
Those tests have been split into smaller tests.
There was also an excessive amount of method chaining (7 -9 method calls in a line).
Most of those have been simplified i.e. changing toList(0) to head and relying on the implicit toString conversion when doing string ops with objects.
There's still some more lines with a tad too much method chaining in my opinion, but they
are about 3 - 5 calls only.

There's still a few more things to do to clean up the tests, but for now I think it's okay.
