### PR TITLE
[SCISPARK 68] Introduce Dataset object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,16 +47,17 @@ libraryDependencies ++= Seq(
   "org.scalatest" % "scalatest_2.10" % "3.0.0-M15",
   "org.apache.spark" % "spark-core_2.10" % "1.6.0" exclude("org.slf4j", "slf4j-api"),
   "org.apache.spark" % "spark-mllib_2.10" % "1.6.0",
-  //Math Libraries
-  //"org.jblas" % "jblas" % "1.2.3",
+  // Math Libraries
+  // "org.jblas" % "jblas" % "1.2.3",
   // other dependencies here
   "org.scalanlp" %% "breeze" % "0.11.2",
   "org.json4s" %% "json4s-native" % "3.2.11",
   // native libraries greatly improve performance, but increase jar sizes.
   "org.scalanlp" %% "breeze-natives" % "0.11.2",
   // Nd4j scala api with netlib-blas backend
-  "org.nd4j" % "nd4s_2.10" % "0.4-rc3.8",
-  "org.nd4j" % "nd4j-x86" % "0.4-rc3.8",
+  // "org.nd4j" % "nd4s_2.10" % "0.5.0",
+  "org.nd4j" % "nd4j-native" % "0.5.0" classifier "" classifier "linux-x86_64",
+  "org.nd4j" % "nd4j-kryo_2.10" % "0.5.0",
   "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.8.1",

--- a/src/main/scala/org/dia/core/Dataset.scala
+++ b/src/main/scala/org/dia/core/Dataset.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.core
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import ucar.nc2.Attribute
+import ucar.nc2.dataset
+
+import org.dia.utils.NetCDFUtils
+
+/**
+ * Dataset is a logical container for variable arrays.
+ * A NetcdfDataset wraps a LinkedHashMap of variables and
+ * a LinkedHashMap of attributes.
+ */
+class Dataset(val variables: mutable.LinkedHashMap[String, Variable],
+              val attributes: mutable.LinkedHashMap[String, String]) extends Serializable{
+
+  def this(vars : Traversable[(String, Variable)], attr : Traversable[(String, String)]) {
+    this(new mutable.LinkedHashMap[String, Variable] ++= vars,
+         new mutable.LinkedHashMap[String, String] ++= attr)
+  }
+
+  def this(vars : Iterable[ucar.nc2.Variable], attr : Iterable[Attribute]) {
+    this(vars.map(p => (p.getFullName, new Variable(p))), attr.map(p => NetCDFUtils.convertAttribute(p)))
+  }
+
+  def this(nvar: dataset.NetcdfDataset) {
+    this(nvar.getVariables.asScala, nvar.getGlobalAttributes.asScala)
+  }
+
+  /**
+   * Writes attribute in the form of key-value pairs
+   */
+  def insertAttributes(metaDataVar: (String, String)*): Unit = {
+    insertAttributes(metaDataVar)
+  }
+
+  def insertAttributes(metaDataVars: Traversable[(String, String)]): Unit = {
+    attributes ++= metaDataVars
+  }
+
+  /**
+   * Writes variables in the form of key-value pairs
+   */
+  def insertVariable(variables: (Variable)*): Unit = {
+    for (v <- variables) this.variables += ((v.name, v))
+  }
+
+  /**
+   * Access variables.
+   * In Python's netcdf Dataset, variables can be accessed as
+   * members of classes like so:
+   *    dataset['variable']
+   * In scala, variables can be access with the
+   * apply function like so:
+   * dataset("variable")
+   *
+   * @param key the variable name
+   * @return the variable
+   */
+  def apply(key: String): Variable = variables(key)
+
+  /**
+   * Access attribute values.
+   * In Python's netcdf variable, attributes can be accessed as
+   * members of classes like so:
+   *    variable.attribute1
+   * In scala we can't do that so we access attributes in
+   * datasets like so:
+   * dataset.attr("attribute")
+   *
+   * @param key the attribute name
+   * @return the attribute value
+   */
+  def attr(key: String): String = attributes(key)
+
+  /**
+   * Creates a clone of the variable
+   *
+   * @return
+   */
+  def copy(): Dataset = new Dataset(variables.clone(), attributes.clone())
+
+  override def toString: String = {
+    val header = "root group ...\n"
+    val variableString = variables.map({case (str, varb) => varb.dataType + " " + str})
+    val footer = "\tvariables: " + variableString + "\n"
+    val body = new StringBuilder()
+    body.append(header)
+    for ((k, v) <- attributes) {
+      body.append("\t" + k + ": " + v + "\n")
+    }
+    body.append(footer.replaceAll("(ArrayBuffer|\\(|\\))", ""))
+    body.toString()
+  }
+
+  override def equals(any: Any): Boolean = {
+    val dataset = any.asInstanceOf[Dataset]
+    dataset.attributes == this.attributes &&
+    dataset.variables == this.variables
+  }
+
+  override def hashCode(): Int = super.hashCode()
+}

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -62,9 +62,16 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
   sparkContext.setLocalProperty(ARRAY_LIB, BREEZE_LIB)
 
 
+  /**
+   * We use kryo serialization.
+   * As of nd4j 0.5.0 we need to add the Nd4jRegistrar to avoid nd4j serialization errors.
+   * These errors come in the form of NullPointerErrors.
+   * @param conf Configuration for a spark application
+   */
   def this(conf: SparkConf) {
     this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryo.classesToRegister", "java.lang.Thread")
+      .set("spark.kryo.registrator", "org.nd4j.Nd4jRegistrator")
       .set("spark.kryoserializer.buffer.max", "256MB")))
   }
 
@@ -89,9 +96,9 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
    * Some datasets (like those hosted by gesdisc) require http credentials
    * for authentiation and access.
    *
-   * @param uri
-   * @param username
-   * @param password
+   * @param uri webpage url
+   * @param username the username used for authentication
+   * @param password the password used for authentication
    */
   def addHTTPCredential(uri: String, username: String, password: String): Unit = {
     HTTPCredentials = HTTPCredentials.+:((uri, username, password))

--- a/src/main/scala/org/dia/tensors/SliceableArray.scala
+++ b/src/main/scala/org/dia/tensors/SliceableArray.scala
@@ -24,9 +24,9 @@ trait SliceableArray {
 
   type T <: SliceableArray
 
-  def rows: Int
+  def rows(): Int
 
-  def cols: Int
+  def cols(): Int
 
   def shape: Array[Int]
 

--- a/src/test/java/org/dia/core/DatasetTest.scala
+++ b/src/test/java/org/dia/core/DatasetTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.core
+
+import org.scalatest.FunSuite
+
+import org.dia.utils.NetCDFUtils
+
+class DatasetTest extends FunSuite {
+
+  val netcdfDataset = NetCDFUtils.loadNetCDFDataSet("src/test/resources/Netcdf/nc_3B42_daily.2008.01.02.7.bin.nc")
+  val Dataset = new Dataset(netcdfDataset)
+
+  test("testCopy") {
+    val copy = Dataset.copy()
+    assert(copy == Dataset)
+  }
+
+  test("testAttributes") {
+    val aerosolAttr = Dataset.attr("FF_GLOBAL\\.Server")
+    assert(aerosolAttr == "DODS FreeFrom based on FFND release 4.2.3")
+  }
+
+  test("testVariables") {
+    val dataVar = netcdfDataset.findVariable("data")
+    val variable = new Variable(dataVar)
+    assert(Dataset("data") == variable)
+  }
+
+  test("testApply") {
+    val dataVar = netcdfDataset.findVariable("data")
+    val variable = new Variable(dataVar)
+    assert(Dataset("data") == variable)
+  }
+
+  test("testInsertAttributes") {
+    val attr = "Hi Five!"
+    val attrName = "Greeting"
+    Dataset.insertAttributes((attrName, attr))
+    assert(Dataset.attr(attrName) == attr)
+  }
+
+  test("testToString") {
+    val string = "root group ...\n" +
+                 "\tFF_GLOBAL\\.Server: DODS FreeFrom based on FFND release 4.2.3\n" +
+                 "\t_CoordSysBuilder: ucar.nc2.dataset.conv.DefaultConvention\n" +
+                 "\tGreeting: Hi Five!\n" +
+                 "\tvariables: float data\n"
+    assert(Dataset.toString == string)
+  }
+}

--- a/src/test/scala/org/dia/tensors/SciTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/SciTensorTest.scala
@@ -25,7 +25,7 @@ import org.dia.core.SciTensor
 class SciTensorTest extends FunSuite {
 
   test("ApplyNullary") {
-    val square = Nd4j.create((0 to 9).toArray, Array(3, 3))
+    val square = Nd4j.create((0d to 9d by 1d).toArray, Array(3, 3))
     val absT = new Nd4jTensor(square)
     val absTCopy = absT.copy
     val sciT = new SciTensor("sample", absT)

--- a/src/test/scala/org/dia/tensors/perf/Nd4JPerformanceTest.scala
+++ b/src/test/scala/org/dia/tensors/perf/Nd4JPerformanceTest.scala
@@ -18,7 +18,6 @@
 package org.dia.tensors.perf
 
 import org.nd4j.linalg.factory.Nd4j
-import org.nd4s.Implicits._
 import org.scalatest.FunSuite
 
 /**
@@ -35,9 +34,9 @@ class Nd4JPerformanceTest extends FunSuite {
        * subtraction
        */
       val start = System.nanoTime()
-      val m3 = m1 - m2
+      val m3 = m1.sub(m2)
       val stop = System.nanoTime()
-      println((stop - start))
+      println(stop - start)
     }
     assert(true)
   }
@@ -51,7 +50,7 @@ class Nd4JPerformanceTest extends FunSuite {
        * element-wise multiplication
        */
       val start = System.nanoTime()
-      val m3 = m1 * m2
+      val m3 = m1.mul(m2)
       val stop = System.nanoTime()
       println(stop - start)
     }


### PR DESCRIPTION
addresses issue #68 
@BrianWilson1 
@kwhitehall 
@chrismattmann 

Here's the dataset object.
I went ahead and implemented both Variable and Dataset, which is a collection of Variables.
Dataset consists of two LinkedHasmap.
One to store the variable arrays, and the other to store the attributes.

The toString tries to closely match python's netCDF4 Dataset printing.

I figured we are still going to have discussions on operations on bundles vs not having operations on bundles. For now both Variable and Dataset have no operations on them. I would wait for some consensus but I figured having discussions on an implemented decision choice is better than discussing an imaginary one.

If you want to make some linear algebra calls you have to get to the underlying tensor like so :

Dataset('variable')()

Dataset('variable') -> gives you a variable object
Dataset('variable')() -> gives you the underlying tensor object with all the ops
This was to mimic the python netCDF4 api call :
Dataset['variable'][:]

Let's continue our discussion on api and layers of abstraction/organization of netcdf data.
