### PR TITLE
[SCISPARK 101] Build.sbt add apache license + change project name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import sbt.Resolver
 
 assemblyJarName in assembly := "SciSpark.jar"
 
-name := "SciSparkTestExperiments"
+name := "SciSpark"
+
+organization := "org.dia"
 
 version := "1.0"
 


### PR DESCRIPTION
Added the apache license to build.sbt and changed the project name from scisparktestexperiments to scispark. Changed organization to org.dia

Addresses issue #101 
