### PR TITLE
[SCISPARK 10] Branch 0.3 esip

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
   "org.scalanlp" %% "breeze-natives" % "0.11.2",
   // Nd4j scala api with netlib-blas backend
   // "org.nd4j" % "nd4s_2.10" % "0.5.0",
-  "org.nd4j" % "nd4j-native" % "0.5.0" classifier "" classifier "linux-x86_64",
+  "org.nd4j" % "nd4j-x86" % "0.4-rc3.8",
   "org.nd4j" % "nd4j-kryo_2.10" % "0.5.0",
   "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import sbt.Resolver
 
 assemblyJarName in assembly := "SciSpark.jar"
 
-name := "SciSparkTestExperiments"
+name := "SciSpark"
+
+organization := "org.dia"
 
 version := "1.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,6 @@ libraryDependencies ++= Seq(
   // Nd4j scala api with netlib-blas backend
   // "org.nd4j" % "nd4s_2.10" % "0.5.0",
   "org.nd4j" % "nd4j-x86" % "0.4-rc3.8",
-  "org.nd4j" % "nd4j-kryo_2.10" % "0.5.0",
   "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.8.1",

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -69,10 +69,7 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
    * @param conf Configuration for a spark application
    */
   def this(conf: SparkConf) {
-    this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-      .set("spark.kryo.classesToRegister", "java.lang.Thread")
-      .set("spark.kryo.registrator", "org.nd4j.Nd4jRegistrator")
-      .set("spark.kryoserializer.buffer.max", "256MB")))
+    this(new SparkContext(conf))
   }
 
   def this(uri: String, name: String) {

--- a/src/test/scala/org/dia/tensors/SciTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/SciTensorTest.scala
@@ -25,7 +25,7 @@ import org.dia.core.SciTensor
 class SciTensorTest extends FunSuite {
 
   test("ApplyNullary") {
-    val square = Nd4j.create((0d to 9d by 1d).toArray, Array(3, 3))
+    val square = Nd4j.create((0d to 8d by 1d).toArray, Array(3, 3))
     val absT = new Nd4jTensor(square)
     val absTCopy = absT.copy
     val sciT = new SciTensor("sample", absT)


### PR DESCRIPTION
This issues issue #10 

The PR reverts back nd4j to the original version that works on all platforms.
The PR also changes the organization to org.dia and project name to scispark instead of scisparktestexperiments.
