### PR TITLE
[SCISPARK 106] Changes to Dataset class and RandomAccess Reading

### DIFF
--- a/src/main/scala/org/dia/core/SciDataset.scala
+++ b/src/main/scala/org/dia/core/SciDataset.scala
@@ -30,8 +30,8 @@ import org.dia.utils.NetCDFUtils
  * A NetcdfDataset wraps a LinkedHashMap of variables and
  * a LinkedHashMap of attributes.
  */
-class Dataset(val variables: mutable.LinkedHashMap[String, Variable],
-              val attributes: mutable.LinkedHashMap[String, String]) extends Serializable{
+class SciDataset(val variables: mutable.LinkedHashMap[String, Variable],
+                 val attributes: mutable.LinkedHashMap[String, String]) extends Serializable{
 
   def this(vars : Traversable[(String, Variable)], attr : Traversable[(String, String)]) {
     this(new mutable.LinkedHashMap[String, Variable] ++= vars,
@@ -44,6 +44,10 @@ class Dataset(val variables: mutable.LinkedHashMap[String, Variable],
 
   def this(nvar: dataset.NetcdfDataset) {
     this(nvar.getVariables.asScala, nvar.getGlobalAttributes.asScala)
+  }
+
+  def this(nvar: dataset.NetcdfDataset, vars: List[String]) {
+    this(vars.map(vr => nvar.findVariable(vr)), nvar.getGlobalAttributes.asScala)
   }
 
   /**
@@ -97,7 +101,7 @@ class Dataset(val variables: mutable.LinkedHashMap[String, Variable],
    *
    * @return
    */
-  def copy(): Dataset = new Dataset(variables.clone(), attributes.clone())
+  def copy(): SciDataset = new SciDataset(variables.clone(), attributes.clone())
 
   override def toString: String = {
     val header = "root group ...\n"
@@ -113,7 +117,7 @@ class Dataset(val variables: mutable.LinkedHashMap[String, Variable],
   }
 
   override def equals(any: Any): Boolean = {
-    val dataset = any.asInstanceOf[Dataset]
+    val dataset = any.asInstanceOf[SciDataset]
     dataset.attributes == this.attributes &&
     dataset.variables == this.variables
   }

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -20,6 +20,9 @@ package org.dia.core
 import scala.collection.mutable
 import scala.io.Source
 
+import org.apache.hadoop.conf._
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.Path
 import org.apache.log4j.LogManager
 
 import org.apache.spark.{SparkConf, SparkContext}
@@ -71,6 +74,7 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
   def this(conf: SparkConf) {
     this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryo.classesToRegister", "java.lang.Thread")
+      .set("spark.kryo.classesToRegister", "scala.collection.mutable.LinkedHashMap")
       .set("spark.kryo.registrator", "org.nd4j.Nd4jRegistrator")
       .set("spark.kryoserializer.buffer.max", "256MB")))
   }
@@ -154,6 +158,31 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
       sciT
     })
     rdd
+  }
+
+  /**
+   * Constructs an SRDD from a file of URI's pointing to NetCDF datasets and a list of variable names.
+   * If no names are provided then all variable arrays in the file are loaded.
+   * The URI could be an OpenDapURL or a filesystem path.
+   *
+   * For reading from HDFS check NetcdfDFSFile.
+   */
+  def NetcdfRandomAccessDatasets(path: String,
+                                 varName: List[String] = Nil,
+                                 minPartitions: Int = 2): RDD[SciDataset] = {
+
+    val fs = FileSystem.get(new Configuration())
+    val FileStatuses = fs.listStatus(new Path(path))
+    val fileNames = FileStatuses.map(p => p.getPath.getName)
+    val nameRDD = sparkContext.parallelize(fileNames)
+
+    nameRDD.map(fileName => {
+      val k = NetCDFUtils.loadDFSNetCDFDataSet(path, path + fileName, 4000)
+      varName match {
+        case Nil => new SciDataset (k)
+        case s : List[String] => new SciDataset(k, s)
+      }
+    })
   }
 
   /**

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -74,7 +74,6 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
   def this(conf: SparkConf) {
     this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.kryo.classesToRegister", "java.lang.Thread")
-      .set("spark.kryo.classesToRegister", "scala.collection.mutable.LinkedHashMap")
       .set("spark.kryo.registrator", "org.nd4j.Nd4jRegistrator")
       .set("spark.kryoserializer.buffer.max", "256MB")))
   }

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -37,7 +37,7 @@ class SciTensor(val variables: mutable.Map[String, AbstractTensor]) extends Seri
 
   val LOG = org.slf4j.LoggerFactory.getLogger(this.getClass)
   val metaData = new mutable.HashMap[String, String]
-  var varInUse = variables.toArray.apply(0)._1
+  var varInUse = variables.head._1
 
   def this(variableName: String, array: AbstractTensor) {
     this(new mutable.LinkedHashMap[String, AbstractTensor] += ((variableName, array)))
@@ -221,8 +221,8 @@ class SciTensor(val variables: mutable.Map[String, AbstractTensor]) extends Seri
   /**
    * Computes the mean along the given axis of the variable in use.
    *
-   * @param axis
-   * @return
+   * @param axis the axis to take the mean along (can be more than one axis)
+   * @return the reduced array with means taken along the specified dimension(s)
    */
   def mean(axis: Int*): SciTensor = {
     variables(varInUse).mean(axis: _*)
@@ -232,7 +232,7 @@ class SciTensor(val variables: mutable.Map[String, AbstractTensor]) extends Seri
    * Computes and returns the array broadcasted to
    * the specified shape requirements.
    *
-   * @param shape
+   * @param shape the new shape to be broadcasted to
    * @return
    */
   def broadcast(shape: Array[Int]): SciTensor = {

--- a/src/main/scala/org/dia/utils/NetCDFUtils.scala
+++ b/src/main/scala/org/dia/utils/NetCDFUtils.scala
@@ -46,9 +46,9 @@ object NetCDFUtils extends Serializable {
    * Some datasets (like those hosted by gesdisc) require http credentials
    * for authentiation and access.
    *
-   * @param url
-   * @param username
-   * @param password
+   * @param url the http url to connect to
+   * @param username the username field
+   * @param password the password field
    */
   def setHTTPAuthentication(url: String, username: String, password: String): Unit = {
     val urlobj = new URL(url)
@@ -164,10 +164,10 @@ object NetCDFUtils extends Serializable {
     } catch {
       case e: java.io.IOException =>
         LOG.error("Couldn't open dataset %s%s".format(dfsUri, location))
-        null
+        throw e
       case ex: Exception =>
         LOG.error("Something went wrong while reading %s%s".format(dfsUri, location))
-        null
+        throw ex
     }
   }
 

--- a/src/test/java/org/dia/core/SciDatasetTest.scala
+++ b/src/test/java/org/dia/core/SciDatasetTest.scala
@@ -21,10 +21,10 @@ import org.scalatest.FunSuite
 
 import org.dia.utils.NetCDFUtils
 
-class DatasetTest extends FunSuite {
+class SciDatasetTest extends FunSuite {
 
   val netcdfDataset = NetCDFUtils.loadNetCDFDataSet("src/test/resources/Netcdf/nc_3B42_daily.2008.01.02.7.bin.nc")
-  val Dataset = new Dataset(netcdfDataset)
+  val Dataset = new SciDataset(netcdfDataset)
 
   test("testCopy") {
     val copy = Dataset.copy()

--- a/src/test/scala/org/dia/core/SciSparkContextTest.scala
+++ b/src/test/scala/org/dia/core/SciSparkContextTest.scala
@@ -46,8 +46,8 @@ class SciSparkContextTest extends FunSuite with BeforeAndAfter {
     val collect = smoothedSRDD.map(_ <= 241.0).collect()
 
     collect.foreach(t => {
-      for (i <- 0 to t.tensor.rows - 1) {
-        for (j <- 0 to t.tensor.cols - 1) {
+      for (i <- 0 until t.tensor.rows) {
+        for (j <- 0 until t.tensor.cols) {
           if (t.tensor(i, j) > 241.0) {
             assert(false, "Indices : (" + i + "," + j + ") has value " + t.tensor(i, j) + "which is greater than 241.0")
           }
@@ -62,9 +62,20 @@ class SciSparkContextTest extends FunSuite with BeforeAndAfter {
    */
   test("NetcdfDFSFile.Local") {
     val variable = "data"
-    val rdd = sc.NetcdfDFSFile("src/test/resources/Netcdf", List(variable))
+    val rdd = sc.NetcdfDFSFile("src/test/resources/Netcdf/", List(variable))
     val collected = rdd.collect
 
     assert(collected.length == 2)
+  }
+
+  /**
+   * Creates SRDD from a directory with NetCDF files in it.
+   */
+  test("NetcdfRandomAccessFile") {
+    val variable = "data"
+    val rdd = sc.NetcdfRandomAccessDatasets("src/test/resources/Netcdf/", List(variable))
+    val count = rdd.count()
+
+    assert(count == 2)
   }
 }


### PR DESCRIPTION
This change is two fold.
1. Addresses issue #106 - the Dataset class is now named SciDataset.
2. We now have a NetcdfRandomAccessDatasets function which reads given an hdfs path and a list of variables will construct a NetcdfDataset object that's backed by a HDFSRandomAccessFile.

This allows us to only extract the variables that we are using, rather than pulling in the entire dataset into memory. I'll have some performance results for this.

If no variable List has been passed then it reads the entire dataset.

Minor changes :
1. I needed to add mutable.LinkedHashMap to kryo (was throwing serializability errors otherwise)
2. minor comments etc.
