### PR TITLE
[SCISPARK 109] remove kryo serialization for thread class

### DIFF
--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -70,7 +70,6 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
    */
   def this(conf: SparkConf) {
     this(new SparkContext(conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-      .set("spark.kryo.classesToRegister", "java.lang.Thread")
       .set("spark.kryo.registrator", "org.nd4j.Nd4jRegistrator")
       .set("spark.kryoserializer.buffer.max", "256MB")))
   }


### PR DESCRIPTION
Let's refrain from serializing the thread class. 
If we are in a position where we have to use it, then just call it using the full classpath i.e.  java.lang.Thread....

The PR addresses issue #109 .
