### PR TITLE
[SCISPARK 98] Put back normal numeric ops syntax

### DIFF
--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -136,21 +136,22 @@ class SciTensor(val variables: mutable.Map[String, AbstractTensor]) extends Seri
   def *(scalar: Double): SciTensor = this.tensor * scalar
 
   // copy operators
-  def :+(other: SciTensor): SciTensor = this.tensor :+ other.tensor
+  def +=(other: SciTensor): SciTensor = this.tensor += other.tensor
 
-  def :+(scalar: Double): SciTensor = this.tensor :+ scalar
+  def +=(scalar: Double): SciTensor = this.tensor += scalar
 
-  def :-(other: SciTensor): SciTensor = this.tensor :- other.tensor
+  def -=(other: SciTensor): SciTensor = this.tensor -= other.tensor
 
-  def :-(scalar: Double): SciTensor = this.tensor :- scalar
+  def -=(scalar: Double): SciTensor = this.tensor -= scalar
 
-  def :/(other: SciTensor): SciTensor = this.tensor :/ other.tensor
+  def /=(other: SciTensor): SciTensor = this.tensor /= other.tensor
 
-  def :/(scalar: Double): SciTensor = this.tensor :/ scalar
+  def /=(scalar: Double): SciTensor = this.tensor /= scalar
 
-  def :*(other: SciTensor): SciTensor = this.tensor :* other.tensor
+  def *=
+  (other: SciTensor): SciTensor = this.tensor *= other.tensor
 
-  def :*(scalar: Double): SciTensor = this.tensor :* scalar
+  def *=(scalar: Double): SciTensor = this.tensor *= scalar
 
 
   /**

--- a/src/main/scala/org/dia/core/SciTensor.scala
+++ b/src/main/scala/org/dia/core/SciTensor.scala
@@ -118,7 +118,6 @@ class SciTensor(val variables: mutable.Map[String, AbstractTensor]) extends Seri
    */
   def **(other: SciTensor): SciTensor = this.tensor ** other.tensor
 
-  // in-place operators
   def +(other: SciTensor): SciTensor = this.tensor + other.tensor
 
   def +(scalar: Double): SciTensor = this.tensor + scalar
@@ -135,7 +134,6 @@ class SciTensor(val variables: mutable.Map[String, AbstractTensor]) extends Seri
 
   def *(scalar: Double): SciTensor = this.tensor * scalar
 
-  // copy operators
   def +=(other: SciTensor): SciTensor = this.tensor += other.tensor
 
   def +=(scalar: Double): SciTensor = this.tensor += scalar
@@ -148,8 +146,7 @@ class SciTensor(val variables: mutable.Map[String, AbstractTensor]) extends Seri
 
   def /=(scalar: Double): SciTensor = this.tensor /= scalar
 
-  def *=
-  (other: SciTensor): SciTensor = this.tensor *= other.tensor
+  def *=(other: SciTensor): SciTensor = this.tensor *= other.tensor
 
   def *=(scalar: Double): SciTensor = this.tensor *= scalar
 

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -54,17 +54,17 @@ trait AbstractTensor extends Serializable with SliceableArray {
   def /(array: AbstractTensor): T
   def /(scalar: Double): T
 
-  def :+(array: AbstractTensor): T
-  def :+(scalar: Double): T
+  def +=(array: AbstractTensor): T
+  def +=(scalar: Double): T
 
-  def :-(array: AbstractTensor): T
-  def :-(scalar: Double): T
+  def -=(array: AbstractTensor): T
+  def -=(scalar: Double): T
 
-  def :*(array: AbstractTensor): T
-  def :*(scalar: Double): T
+  def *=(array: AbstractTensor): T
+  def *=(scalar: Double): T
 
-  def :/(array: AbstractTensor): T
-  def :/(scalar: Double): T
+  def /=(array: AbstractTensor): T
+  def /=(scalar: Double): T
 
   /**
    * Linear Algebra Operations

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -70,37 +70,38 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
 
   def put(value: Double, shape: Int*): Unit = tensor.update(shape(0), shape(1), value)
 
-  def +(array: AbstractTensor): BreezeTensor = tensor :+= array.tensor
+  def +(array: AbstractTensor): BreezeTensor = tensor + array.tensor
 
-  def +(scalar: Double): BreezeTensor = tensor :+= scalar
+  def +(scalar: Double): BreezeTensor = tensor + scalar
 
-  def -(array: AbstractTensor): BreezeTensor = tensor :-= array.tensor
+  def -(array: AbstractTensor): BreezeTensor = tensor - array.tensor
 
-  def -(scalar: Double): BreezeTensor = tensor :-= scalar
+  def -(scalar: Double): BreezeTensor = tensor - scalar
 
-  def /(array: AbstractTensor): BreezeTensor = tensor :/= array.tensor
+  def /(array: AbstractTensor): BreezeTensor = tensor / array.tensor
 
-  def /(scalar: Double): BreezeTensor = tensor :/= scalar
+  def /(scalar: Double): BreezeTensor = tensor / scalar
 
-  def *(array: AbstractTensor): BreezeTensor = tensor *= array.tensor
+  def *(array: AbstractTensor): BreezeTensor = tensor :* array.tensor
 
-  def *(scalar: Double): BreezeTensor = tensor :*= scalar
+  def *(scalar: Double): BreezeTensor = tensor :* scalar
 
-  def :+(array: AbstractTensor): BreezeTensor = tensor + array.tensor
+  def +=(array: AbstractTensor): BreezeTensor = tensor :+= array.tensor
 
-  def :+(scalar: Double): BreezeTensor = tensor + scalar
+  def +=(scalar: Double): BreezeTensor = tensor :+= scalar
 
-  def :-(array: AbstractTensor): BreezeTensor = tensor - array.tensor
+  def -=(array: AbstractTensor): BreezeTensor = tensor :-= array.tensor
 
-  def :-(scalar: Double): BreezeTensor = tensor - scalar
+  def -=(scalar: Double): BreezeTensor = tensor :-= scalar
 
-  def :/(array: AbstractTensor): BreezeTensor = tensor / array.tensor
+  def /=(array: AbstractTensor): BreezeTensor = tensor :/= array.tensor
 
-  def :/(scalar: Double): BreezeTensor = tensor / scalar
+  def /=(scalar: Double): BreezeTensor = tensor :/= scalar
 
-  def :*(array: AbstractTensor): BreezeTensor = tensor :* array.tensor
+  def *=(array: AbstractTensor): BreezeTensor = tensor :*= array.tensor
 
-  def :*(scalar: Double): BreezeTensor = tensor :* scalar
+  def *=(scalar: Double): BreezeTensor = tensor :*= scalar
+
 
   /**
    * Masking operations

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -69,39 +69,37 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
   def put(value: Double, shape: Int*): Unit = tensor.putScalar(shape.toArray, value)
 
-  def +(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.addi(array.tensor))
+  def +(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.add(array.tensor))
+
+  def +(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.add(scalar))
+
+  def -(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.sub(array.tensor))
+
+  def -(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.sub(scalar))
+
+  def /(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.div(array.tensor))
+
+  def /(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.div(scalar))
+
+  def *(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.mul(array.tensor))
+
+  def *(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.mul(scalar))
 
   def +=(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.addi(array.tensor))
 
-  def +(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.addi(scalar))
+  def +=(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.addi(scalar))
 
-  def -(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.subi(array.tensor))
+  def -=(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.subi(array.tensor))
 
-  def -(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.subi(scalar))
+  def -=(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.subi(scalar))
 
-  def /(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.divi(array.tensor))
+  def /=(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.divi(array.tensor))
 
-  def /(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.divi(scalar))
+  def /=(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.divi(scalar))
 
-  def *(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.muli(array.tensor))
+  def *=(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.muli(array.tensor))
 
-  def *(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.muli(scalar))
-
-  def :+(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.add(array.tensor))
-
-  def :+(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.add(scalar))
-
-  def :-(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.sub(array.tensor))
-
-  def :-(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.sub(scalar))
-
-  def :/(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.div(array.tensor))
-
-  def :/(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.div(scalar))
-
-  def :*(array: AbstractTensor): Nd4jTensor = new Nd4jTensor(tensor.mul(array.tensor))
-
-  def :*(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.mul(scalar))
+  def *=(scalar: Double): Nd4jTensor = new Nd4jTensor(tensor.muli(scalar))
 
   /**
    * Masking operations

--- a/src/test/scala/org/dia/core/SRDDTest.scala
+++ b/src/test/scala/org/dia/core/SRDDTest.scala
@@ -125,9 +125,9 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
   /**
    * Test matrix artihmetic
    */
-  test("inplacematrixAddition") {
+  test("outofplacematrixAddition") {
     val t = uSRDD.collect().toList
-    logger.info("In inPlaceMatrixAddition test ...")
+    logger.info("In outofPlaceMatrixAddition test ...")
     logger.info("The sciTensor is: " + t)
     logger.info("The values are: " + t(0).variables.values.toList)
     // test scalar addition
@@ -138,7 +138,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     assert(count == 0)
   }
 
-  test("outofplaceMatrixAddition") {
+  test("inplaceMatrixAddition") {
     // test scalar addition
     val t = uSRDD.map(p => p("randVar") += 2.0).collect().toList
     logger.info("Addition: " + t(0).variables.values.head)
@@ -147,7 +147,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     assert(count == 0)
   }
 
-  test("orderedPairWiseInplaceMatrixAddition") {
+  test("orderedPairWiseOutplaceMatrixAddition") {
     // test matrix addition
     // order the fakeURLs then sum pairs
     val ordered = uSRDD.flatMap(p => {
@@ -171,7 +171,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     }
   }
 
-  test("orderedPairWiseOutofplaceMatrixAddition") {
+  test("orderedPairWiseInplaceMatrixAddition") {
     val ordered = uSRDD.flatMap(p => {
       List((p.metaData("SOURCE").toInt, p), (p.metaData("SOURCE").toInt + 1, p))
     }).groupBy(_._1)
@@ -191,7 +191,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     }
   }
 
-  test("inPlaceMatrixSubtraction") {
+  test("OutPlaceMatrixSubtraction") {
     val t = uSRDD.collect().toList
     logger.info("The sciTensor is: " + t)
     logger.info("The values are: " + t(0).variables.values.toList)
@@ -203,7 +203,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     assert(count == 0)
   }
 
-  test("OutofplaceMatrixSubtraction") {
+  test("InofplaceMatrixSubtraction") {
     // test scalar subtraction
     val t = uSRDD.map(p => p("randVar") -= 2.0).collect().toList
     val y1 = t(0).variables.values.head.data
@@ -211,7 +211,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     assert(count == 0)
   }
 
-  test("orderedPairWiseOutofplaceMatrixSubtraction") {
+  test("orderedPairWiseOutplaceMatrixSubtraction") {
     // test matrix subtraction
     // order the fakeURLs then subtract pairs
     val ordered = uSRDD.flatMap(p => {
@@ -254,7 +254,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     }
   }
 
-  test("matrixDivision") {
+  test("OutPlaceMatrixDivision") {
     val t = uSRDD.collect().toList
     logger.info("In matrixDivision test ...")
     logger.info("The sciTensor is: " + t)
@@ -266,14 +266,14 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     assert(y.count(_ == 0.5) == 30)
   }
 
-  test("outOfPlaceMatrixDivision") {
+  test("InPlaceMatrixDivision") {
     val t = uSRDD.map(p => p("randVar") /= 2.0).collect().toList(0)
     logger.info("Division: " + t.variables.values.head)
     val y1 = t.variables.values.head.data
     assert(y1.count(_ == 0.5) == 30)
   }
 
-  test("orderedPairWiseOutOfPlaceMatrixDivision") {
+  test("orderedPairWiseInPlaceMatrixDivision") {
     // test matrix division
     // order the fakeURLs then multiply pairs
     val ordered = uSRDD.flatMap(p => {
@@ -295,7 +295,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     }
   }
 
-  test("orderedPairWiseInPlaceMatrixDivision") {
+  test("orderedPairWiseOutPlaceMatrixDivision") {
     val ordered = uSRDD.flatMap(p => {
       List((p.metaData("SOURCE").toInt, p), (p.metaData("SOURCE").toInt + 1, p))
     }).groupBy(_._1)
@@ -316,7 +316,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     }
   }
 
-  test("matrixMultiplication") {
+  test("outPlaceMatrixMultiplication") {
     val t = uSRDD.collect().toList
     logger.info("In matrixMultiplication test ...")
     logger.info("The sciTensor is: " + t)
@@ -328,14 +328,14 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     assert(y.count(_ == 2.0) == 30)
   }
 
-  test("outOfPlaceMatrixMultiplication") {
+  test("InPlaceMatrixMultiplication") {
     // test scalar multiplication
     val t = uSRDD.map(p => p("randVar") *= 2.0)
     val y1 = t.collect().head.data
     assert(y1.count(_ == 2.0) == 30)
   }
 
-  test("orderedPairWiseInPlaceMatrixMultiplication") {
+  test("orderedPairWiseOutPlaceMatrixMultiplication") {
     // test matrix multiplication
     // order the fakeURLs then multiply pairs
     val ordered = uSRDD.flatMap(p => {
@@ -355,7 +355,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     }
   }
 
-  test("orderedPairWiseOutOfPlaceMatrixMultiplication") {
+  test("orderedPairWiseInPlaceMatrixMultiplication") {
     // test matrix multiplication
     // order the fakeURLs then multiply pairs
     val ordered = uSRDD.flatMap(p =>

--- a/src/test/scala/org/dia/core/SRDDTest.scala
+++ b/src/test/scala/org/dia/core/SRDDTest.scala
@@ -140,7 +140,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
 
   test("outofplaceMatrixAddition") {
     // test scalar addition
-    val t = uSRDD.map(p => p("randVar") :+ 2.0).collect().toList
+    val t = uSRDD.map(p => p("randVar") += 2.0).collect().toList
     logger.info("Addition: " + t(0).variables.values.head)
     val y1 = t(0).variables.values.head.data
     val count = y1.count(p => p != 3.0)
@@ -182,7 +182,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
 
     val c = ordered.collect.toList
     val clen = c.length
-    val ew1 = ordered.map(p => p._1("randVar") :+ p._2("randVar"))
+    val ew1 = ordered.map(p => p._1("randVar") += p._2("randVar"))
     val ewList1 = ew1.collect().toList
     val ewLen = ewList1.length
     logger.info("List length before is: " + clen + " and after is length " + ewLen)
@@ -205,7 +205,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
 
   test("OutofplaceMatrixSubtraction") {
     // test scalar subtraction
-    val t = uSRDD.map(p => p("randVar") :- 2.0).collect().toList
+    val t = uSRDD.map(p => p("randVar") -= 2.0).collect().toList
     val y1 = t(0).variables.values.head.data
     val count = y1.count(p => p != -1.0)
     assert(count == 0)
@@ -245,7 +245,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     val c = ordered.collect.toList
     val clen = c.length
 
-    val ew1 = ordered.map(p => p._2("randVar") :- p._1("randVar"))
+    val ew1 = ordered.map(p => p._2("randVar") -= p._1("randVar"))
     val ewList1 = ew1.collect().toList
     val ewLen = ewList1.length
     logger.info("List length before is: " + clen + " and after is length " + ewLen)
@@ -267,7 +267,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
   }
 
   test("outOfPlaceMatrixDivision") {
-    val t = uSRDD.map(p => p("randVar") :/ 2.0).collect().toList(0)
+    val t = uSRDD.map(p => p("randVar") /= 2.0).collect().toList(0)
     logger.info("Division: " + t.variables.values.head)
     val y1 = t.variables.values.head.data
     assert(y1.count(_ == 0.5) == 30)
@@ -286,7 +286,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     val c = ordered.collect.toList
     for (i <- c) logger.info(i._1.metaData + " connected to " + i._2.metaData)
 
-    val ew = ordered.map(p => p._1("randVar") :/ p._2("randVar"))
+    val ew = ordered.map(p => p._1("randVar") /= p._2("randVar"))
     val ewList = ew.collect().toList
     val ewlen = ewList.length
     logger.info("List length before is: " + c.length + " and after is length " + ewlen)
@@ -330,7 +330,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
 
   test("outOfPlaceMatrixMultiplication") {
     // test scalar multiplication
-    val t = uSRDD.map(p => p("randVar") :* 2.0)
+    val t = uSRDD.map(p => p("randVar") *= 2.0)
     val y1 = t.collect().head.data
     assert(y1.count(_ == 2.0) == 30)
   }
@@ -367,7 +367,7 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
       .map(p => (p(0), p(1)))
 
     val c = ordered.count()
-    val ew1 = ordered.map(p => p._1("randVar") :* p._2("randVar"))
+    val ew1 = ordered.map(p => p._1("randVar") *= p._2("randVar"))
     val ewList1 = ew1.collect().toList
     val ewLen = ewList1.length
     logger.info("List length before is: " + c + " and after is length " + ewLen)


### PR DESCRIPTION
The change sets numerics to work as numpy does.

+, -, *, / are all out-of place operaions
+=, -=, *=, /= are all in place operations.

This is to address issue #98 
