### PR TITLE
[SCISPARK 96] Get rid of credentials in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,10 @@
 # check build and test results for their pull requests
 
 # 1. Choose language and target JDKs for parallel  builds
+language: scala
+scala:
+  - 2.10.6
 
-os: osx
-osx_image: xcode8
-sudo: required
-language: java
-
-env: SCALA_VERSION=2.10.6
 # 2. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
 #              (OS X 10.11)
 matrix:
@@ -32,8 +29,9 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      language: scala
-      scala: 2.10.6
+    - os: osx
+      osx_image: xcode8
+      sudo: required
 
 # 3. Setup cache directory for SBT
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,12 @@
 # SciSpark provides this Travis CI configuration file to help contributors
 # check build and test results for their pull requests
 
-# 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
+# 1. Choose language and target JDKs for parallel  builds
+language: scala
+scala:
+  - 2.10.6
+
+# 2. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
 #              (OS X 10.11)
 matrix:
   include:
@@ -27,12 +32,6 @@ matrix:
     - os: osx
       osx_image: xcode8
       sudo: required
-
-
-# 2. Choose language and target JDKs for parallel  builds
-language: scala
-scala:
-  - 2.10.6
 
 # 3. Setup cache directory for SBT
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,12 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      language: scala
+      scala: 2.10.6
     - os: osx
       osx_image: xcode8
       sudo: required
+      language: java
 
 # 3. Setup cache directory for SBT
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,8 @@
 # check build and test results for their pull requests
 
 # 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
-#              (OS X 10.11)
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-    - os: osx
-      osx_image: xcode8
-      sudo: required
-
+sudo: required
+dist: trusty
 
 # 2. Choose language and target JDKs for parallel  builds
 language: scala

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,16 @@
 # check build and test results for their pull requests
 
 # 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
-sudo: required
-dist: trusty
+#              (OS X 10.11)
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode8
+      sudo: required
+
 
 # 2. Choose language and target JDKs for parallel  builds
 language: scala

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,13 @@
 # check build and test results for their pull requests
 
 # 1. Choose language and target JDKs for parallel  builds
-language: scala
-scala:
-  - 2.10.6
 
+os: osx
+osx_image: xcode8
+sudo: required
+language: java
+
+env: SCALA_VERSION=2.10.6
 # 2. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
 #              (OS X 10.11)
 matrix:
@@ -31,10 +34,6 @@ matrix:
       sudo: required
       language: scala
       scala: 2.10.6
-    - os: osx
-      osx_image: xcode8
-      sudo: required
-      language: java
 
 # 3. Setup cache directory for SBT
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
   "org.scalanlp" %% "breeze-natives" % "0.11.2",
   // Nd4j scala api with netlib-blas backend
   // "org.nd4j" % "nd4s_2.10" % "0.5.0",
-  "org.nd4j" % "nd4j-native" % "0.5.0" classifier "" classifier "linux-x86_64",
+  "org.nd4j" % "nd4j-native-platform" % "0.5.0",
   "org.nd4j" % "nd4j-kryo_2.10" % "0.5.0",
   "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",

--- a/src/main/scala/org/dia/utils/NetCDFUtils.scala
+++ b/src/main/scala/org/dia/utils/NetCDFUtils.scala
@@ -135,9 +135,8 @@ object NetCDFUtils extends Serializable {
    * Loads a NetCDF Dataset from a URL.
    */
   def loadNetCDFDataSet(url: String): NetcdfDataset = {
-
     NetcdfDataset.setUseNaNs(false)
-    try {
+    val dataset = try {
       NetcdfDataset.openDataset(url)
     } catch {
       case e: java.io.IOException =>
@@ -147,6 +146,8 @@ object NetCDFUtils extends Serializable {
         LOG.error("Something went wrong while reading %s".format(url))
         throw ex
     }
+    LOG.info("Succesfully downloaded netcdf file from :" + url)
+    dataset
   }
 
   /**

--- a/src/test/resources/TestHTTPCredentials
+++ b/src/test/resources/TestHTTPCredentials
@@ -1,0 +1,2 @@
+username scispark
+password SciSpark1

--- a/src/test/scala/org/dia/core/SRDDTest.scala
+++ b/src/test/scala/org/dia/core/SRDDTest.scala
@@ -35,8 +35,10 @@ import org.dia.utils.NetCDFUtils
 class SRDDTest extends FunSuite with BeforeAndAfter {
 
   val gesdiscUrl = "http://disc2.gesdisc.eosdis.nasa.gov:80"
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   before {
-    NetCDFUtils.setHTTPAuthentication(gesdiscUrl, "scispark", "SciSpark1")
+    NetCDFUtils.setHTTPAuthentication(gesdiscUrl, username, password)
   }
 
   val testLinks = SparkTestConstants.datasetPath

--- a/src/test/scala/org/dia/core/SciSparkContextTest.scala
+++ b/src/test/scala/org/dia/core/SciSparkContextTest.scala
@@ -29,9 +29,10 @@ class SciSparkContextTest extends FunSuite with BeforeAndAfter {
 
   val sc = SparkTestConstants.sc
   val testLinks = SparkTestConstants.datasetPath
-
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   before {
-    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80", "scispark", "SciSpark1")
+    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80", username, password)
   }
 
   /**

--- a/src/test/scala/org/dia/integration/BreezeIntegrationTest.scala
+++ b/src/test/scala/org/dia/integration/BreezeIntegrationTest.scala
@@ -21,6 +21,7 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import org.dia.loaders.NetCDFReader
 import org.dia.tensors.BreezeTensor
+import org.dia.testenv.SparkTestConstants
 import org.dia.utils.NetCDFUtils
 
 /**
@@ -37,11 +38,9 @@ class BreezeIntegrationTest extends FunSuite with BeforeAndAfter{
    * Earth Data login for GESDISC : Authentication
    * https://urs.earthdata.nasa.gov/home
    * You can log in with the following credentials:
-   * Username : scispark
-   * Password : SciSpark1
    */
-  val username = "scispark"
-  val password = "SciSpark1"
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   /** URLs */
   val gesdiscUrl = "http://disc2.gesdisc.eosdis.nasa.gov:80"
   val airsUrl = "http://acdisc-ts1.gesdisc.eosdis.nasa.gov:80"

--- a/src/test/scala/org/dia/integration/Nd4jIntegrationTest.scala
+++ b/src/test/scala/org/dia/integration/Nd4jIntegrationTest.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import org.dia.loaders.NetCDFReader
 import org.dia.tensors.Nd4jTensor
+import org.dia.testenv.SparkTestConstants
 import org.dia.utils.NetCDFUtils
 
 /**
@@ -38,11 +39,9 @@ class Nd4jIntegrationTest extends FunSuite with BeforeAndAfter {
    * Earth Data login for GESDISC : Authentication
    * https://urs.earthdata.nasa.gov/home
    * You can log in with the following credentials:
-   * Username : scispark
-   * Password : SciSpark1
    */
-  val username = "scispark"
-  val password = "SciSpark1"
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   /** URLs */
   val gesdiscUrl = "http://disc2.gesdisc.eosdis.nasa.gov:80"
   val airsUrl = "http://acdisc-ts1.gesdisc.eosdis.nasa.gov:80"

--- a/src/test/scala/org/dia/loaders/LoadersTest.scala
+++ b/src/test/scala/org/dia/loaders/LoadersTest.scala
@@ -33,9 +33,11 @@ import org.dia.testenv.SparkTestConstants
 class LoadersTest extends FunSuite with BeforeAndAfter {
 
   val sc = SparkTestConstants.sc
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
 
   before {
-    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80/", "scispark", "SciSpark1")
+    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80/", username, password)
   }
 
   /**

--- a/src/test/scala/org/dia/testenv/SparkTestConstants.scala
+++ b/src/test/scala/org/dia/testenv/SparkTestConstants.scala
@@ -17,10 +17,23 @@
  */
 package org.dia.testenv
 
+import scala.collection.mutable
+import scala.io.Source
+
 import org.dia.core.SciSparkContext
 
 object SparkTestConstants {
   val sc = new SciSparkContext("local[4]", "test")
   val datasetPath = "src/test/resources/TestLinks2"
   val datasetVariable = "precipitation"
+
+  val credentialsFilePath = "src/test/resources/TestHTTPCredentials"
+  val credentialList = Source.fromFile(credentialsFilePath)
+    .getLines()
+    .map(p => {
+      val split = p.split("\\s+")
+      (split(0), split(1))
+    })
+  val testHTTPCredentials = new mutable.LinkedHashMap[String, String] ++= credentialList
+
 }


### PR DESCRIPTION
Addresses issue #96 
Let's not have credentials in test code.
I have included a TestHTTPCredentials config file.
User's can input their credentials in space separated key value pairs.
These credentials will be used to populate the username and password fields when we run
tests that download data from http authenticated opendap servers.
