### PR TITLE
[SCISPARK 89] Add Coveralls  Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,16 @@ notifications:
 
 # 5. Run maven sbt compile, check style, and test
 install:
-  - sbt compile
   - sbt scalastyle
   - sbt test:scalastyle
-  - sbt test
+
+# 6. Run maven sbt compile, test, and generate coverage reports
+script:
+  - sbt clean
+  - sbt compile
+  - sbt coverage test
+
+# 7. Generate the coverageReport for coveralls
+after_success:
+  - sbt coverageReport coveralls
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ SciSpark
 ====
 
 [![Join the chat at https://gitter.im/scientificspark](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scientificspark/Lobby)
-
 [![Build Status](https://travis-ci.org/SciSpark/SciSpark.svg?branch=master)](https://travis-ci.org/SciSpark/SciSpark)
+[![Coverage Status](https://coveralls.io/repos/github/SciSpark/SciSpark/badge.svg?branch=master)](https://coveralls.io/github/SciSpark/SciSpark?branch=master)
 
 ![picture alt](http://image.slidesharecdn.com/jljkdhlxtlgwcyboil6n-signature-c9af2d5a7f730d5a4779821a7bd1f0333657fd7c0430ac7965a5576c08924b8a-poli-150624001008-lva1-app6891/95/spark-at-nasajplchris-mattmann-nasajpl-29-638.jpg?cb=1435104721)
 #Update

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,5 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 logLevel := Level.Warn
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")


### PR DESCRIPTION
Addresses issue #89
The coveralls tracking page for SciSpark can be found here :
https://coveralls.io/github/SciSpark/SciSpark

This can quickly tell if a branch has the requisite test code or not.
If it doesn't then the coverage report will show a decrease.

I wonder how useful this will be so I consider this more of a trial run.
