### PR TITLE
[SCISPARK 50] write SciTensor to NetcdfFile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,16 @@ notifications:
 
 # 5. Run maven sbt compile, check style, and test
 install:
-  - sbt compile
   - sbt scalastyle
   - sbt test:scalastyle
-  - sbt test
+
+# 6. Run maven sbt compile, test, and generate coverage reports
+script:
+  - sbt clean
+  - sbt compile
+  - sbt coverage test
+
+# 7. Generate the coverageReport for coveralls
+after_success:
+  - sbt coverageReport coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,8 @@
 # check build and test results for their pull requests
 
 # 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
-#              (OS X 10.11)
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-    - os: osx
-      osx_image: xcode8
-      sudo: required
-
+sudo: required
+dist: trusty
 
 # 2. Choose language and target JDKs for parallel  builds
 language: scala

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,16 @@
 # check build and test results for their pull requests
 
 # 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit)
-sudo: required
-dist: trusty
+#              (OS X 10.11)
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode8
+      sudo: required
+
 
 # 2. Choose language and target JDKs for parallel  builds
 language: scala

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ SciSpark
 ====
 
 [![Join the chat at https://gitter.im/scientificspark](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scientificspark/Lobby)
-
 [![Build Status](https://travis-ci.org/SciSpark/SciSpark.svg?branch=master)](https://travis-ci.org/SciSpark/SciSpark)
+[![Coverage Status](https://coveralls.io/repos/github/SciSpark/SciSpark/badge.svg?branch=master)](https://coveralls.io/github/SciSpark/SciSpark?branch=master)
 
 ![picture alt](http://image.slidesharecdn.com/jljkdhlxtlgwcyboil6n-signature-c9af2d5a7f730d5a4779821a7bd1f0333657fd7c0430ac7965a5576c08924b8a-poli-150624001008-lva1-app6891/95/spark-at-nasajplchris-mattmann-nasajpl-29-638.jpg?cb=1435104721)
 #Update

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
   "org.scalanlp" %% "breeze-natives" % "0.11.2",
   // Nd4j scala api with netlib-blas backend
   // "org.nd4j" % "nd4s_2.10" % "0.5.0",
-  "org.nd4j" % "nd4j-native" % "0.5.0" classifier "" classifier "linux-x86_64",
+  "org.nd4j" % "nd4j-native-platform" % "0.5.0",
   "org.nd4j" % "nd4j-kryo_2.10" % "0.5.0",
   "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,5 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 logLevel := Level.Warn
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")

--- a/src/main/scala/org/dia/utils/NetCDFUtils.scala
+++ b/src/main/scala/org/dia/utils/NetCDFUtils.scala
@@ -135,9 +135,8 @@ object NetCDFUtils extends Serializable {
    * Loads a NetCDF Dataset from a URL.
    */
   def loadNetCDFDataSet(url: String): NetcdfDataset = {
-
     NetcdfDataset.setUseNaNs(false)
-    try {
+    val dataset = try {
       NetcdfDataset.openDataset(url)
     } catch {
       case e: java.io.IOException =>
@@ -147,6 +146,8 @@ object NetCDFUtils extends Serializable {
         LOG.error("Something went wrong while reading %s".format(url))
         throw ex
     }
+    LOG.info("Succesfully downloaded netcdf file from :" + url)
+    dataset
   }
 
   /**

--- a/src/test/resources/TestHTTPCredentials
+++ b/src/test/resources/TestHTTPCredentials
@@ -1,0 +1,2 @@
+username scispark
+password SciSpark1

--- a/src/test/scala/org/dia/core/SRDDTest.scala
+++ b/src/test/scala/org/dia/core/SRDDTest.scala
@@ -35,8 +35,10 @@ import org.dia.utils.NetCDFUtils
 class SRDDTest extends FunSuite with BeforeAndAfter {
 
   val gesdiscUrl = "http://disc2.gesdisc.eosdis.nasa.gov:80"
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   before {
-    NetCDFUtils.setHTTPAuthentication(gesdiscUrl, "scispark", "SciSpark1")
+    NetCDFUtils.setHTTPAuthentication(gesdiscUrl, username, password)
   }
 
   val testLinks = SparkTestConstants.datasetPath

--- a/src/test/scala/org/dia/core/SciSparkContextTest.scala
+++ b/src/test/scala/org/dia/core/SciSparkContextTest.scala
@@ -29,9 +29,10 @@ class SciSparkContextTest extends FunSuite with BeforeAndAfter {
 
   val sc = SparkTestConstants.sc
   val testLinks = SparkTestConstants.datasetPath
-
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   before {
-    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80", "scispark", "SciSpark1")
+    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80", username, password)
   }
 
   /**

--- a/src/test/scala/org/dia/integration/BreezeIntegrationTest.scala
+++ b/src/test/scala/org/dia/integration/BreezeIntegrationTest.scala
@@ -21,6 +21,7 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import org.dia.loaders.NetCDFReader
 import org.dia.tensors.BreezeTensor
+import org.dia.testenv.SparkTestConstants
 import org.dia.utils.NetCDFUtils
 
 /**
@@ -37,11 +38,9 @@ class BreezeIntegrationTest extends FunSuite with BeforeAndAfter{
    * Earth Data login for GESDISC : Authentication
    * https://urs.earthdata.nasa.gov/home
    * You can log in with the following credentials:
-   * Username : scispark
-   * Password : SciSpark1
    */
-  val username = "scispark"
-  val password = "SciSpark1"
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   /** URLs */
   val gesdiscUrl = "http://disc2.gesdisc.eosdis.nasa.gov:80"
   val airsUrl = "http://acdisc-ts1.gesdisc.eosdis.nasa.gov:80"

--- a/src/test/scala/org/dia/integration/Nd4jIntegrationTest.scala
+++ b/src/test/scala/org/dia/integration/Nd4jIntegrationTest.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import org.dia.loaders.NetCDFReader
 import org.dia.tensors.Nd4jTensor
+import org.dia.testenv.SparkTestConstants
 import org.dia.utils.NetCDFUtils
 
 /**
@@ -38,11 +39,9 @@ class Nd4jIntegrationTest extends FunSuite with BeforeAndAfter {
    * Earth Data login for GESDISC : Authentication
    * https://urs.earthdata.nasa.gov/home
    * You can log in with the following credentials:
-   * Username : scispark
-   * Password : SciSpark1
    */
-  val username = "scispark"
-  val password = "SciSpark1"
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
   /** URLs */
   val gesdiscUrl = "http://disc2.gesdisc.eosdis.nasa.gov:80"
   val airsUrl = "http://acdisc-ts1.gesdisc.eosdis.nasa.gov:80"

--- a/src/test/scala/org/dia/loaders/LoadersTest.scala
+++ b/src/test/scala/org/dia/loaders/LoadersTest.scala
@@ -33,9 +33,11 @@ import org.dia.testenv.SparkTestConstants
 class LoadersTest extends FunSuite with BeforeAndAfter {
 
   val sc = SparkTestConstants.sc
+  val username = SparkTestConstants.testHTTPCredentials("username")
+  val password = SparkTestConstants.testHTTPCredentials("password")
 
   before {
-    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80/", "scispark", "SciSpark1")
+    sc.addHTTPCredential("http://disc2.gesdisc.eosdis.nasa.gov:80/", username, password)
   }
 
   /**

--- a/src/test/scala/org/dia/tensors/SciTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/SciTensorTest.scala
@@ -17,20 +17,41 @@
  */
 package org.dia.tensors
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
 import org.nd4j.linalg.factory.Nd4j
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import org.dia.core.SciTensor
+import org.dia.utils.NetCDFUtils
 
-class SciTensorTest extends FunSuite {
+class SciTensorTest extends FunSuite with BeforeAndAfterEach{
 
-  test("ApplyNullary") {
+  var absTCopy : AbstractTensor = _
+  var sciT : SciTensor = _
+
+  override def beforeEach(): Unit = {
     val square = Nd4j.create((0d to 9d by 1d).toArray, Array(3, 3))
     val absT = new Nd4jTensor(square)
-    val absTCopy = absT.copy
-    val sciT = new SciTensor("sample", absT)
+    absTCopy = absT.copy
+    sciT = new SciTensor("sample", absT)
+  }
+
+  test("ApplyNullary") {
     val extracted = sciT("sample")()
     assert(extracted.isInstanceOf[org.dia.tensors.AbstractTensor])
     assert(extracted == absTCopy)
+  }
+
+  test("writeToNetCDF") {
+    sciT.writeToNetCDF("TestSciTensor.nc")
+    val newDataset = NetCDFUtils.loadNetCDFDataSet("TestSciTensor.nc")
+    val vars = newDataset.getVariables.asScala.map(p => p.getFullName)
+    val arrayShapePairs = vars.map(p => (p, NetCDFUtils.netCDFArrayAndShape(newDataset, p)))
+
+    val tensors = arrayShapePairs.map({ case(name, (arr, shp)) => (name, new Nd4jTensor(arr, shp))})
+    val sciTNew = new SciTensor(new mutable.HashMap[String, AbstractTensor]() ++= tensors)
+    assert(sciTNew == sciT)
   }
 }

--- a/src/test/scala/org/dia/testenv/SparkTestConstants.scala
+++ b/src/test/scala/org/dia/testenv/SparkTestConstants.scala
@@ -17,10 +17,23 @@
  */
 package org.dia.testenv
 
+import scala.collection.mutable
+import scala.io.Source
+
 import org.dia.core.SciSparkContext
 
 object SparkTestConstants {
   val sc = new SciSparkContext("local[4]", "test")
   val datasetPath = "src/test/resources/TestLinks2"
   val datasetVariable = "precipitation"
+
+  val credentialsFilePath = "src/test/resources/TestHTTPCredentials"
+  val credentialList = Source.fromFile(credentialsFilePath)
+    .getLines()
+    .map(p => {
+      val split = p.split("\\s+")
+      (split(0), split(1))
+    })
+  val testHTTPCredentials = new mutable.LinkedHashMap[String, String] ++= credentialList
+
 }


### PR DESCRIPTION
Addresses issue #50 

Writes the SciTensor variables into a NetcdfFile

Unfortunately this does not preserve dimension names or variable attributes.
SciDataset does. Adding this functionality to SciTensor would break many of the codes we have that use SciTensor.

Dimension names are named by their index in the shape array.
So '1', '2', '3'.

The metaData table is written to the NetcdfFile as global attributes.

I created this PR just to fulfill what was requested in this issue.
SciDataset already supports writing to NetcdfFiles.
