### PR TITLE
[SCISPARK 106] Write SciDataset to local filesystem as a NetCDF file V2

### DIFF
--- a/src/main/scala/org/dia/core/SRDDFunctions.scala
+++ b/src/main/scala/org/dia/core/SRDDFunctions.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.core
+
+import java.io.File
+import java.net.URI
+
+import scala.language.implicitConversions
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
+
+import org.apache.spark.rdd.RDD
+
+/**
+ * Functions on top of the SRDD: an RDD of SciDatasets
+ * To use the functions in SRDDFunctions import it like so :
+ *
+ * import org.dia.core.SRDDFunctions._
+ *
+ * You can call the functions on all RDD's of type RDD[SciTensor]
+ *
+ * @param self the RDD to call functions on
+ */
+class SRDDFunctions(self: RDD[SciDataset]) extends Serializable {
+
+  /**
+   * Writes the RDD of SciDatasets under a directory in hdfs.
+   * This is a quick fix function that writes to the local filesystem
+   * under tmp and the copies it to hdfs.
+   * TODO :: Write netcdfFile directly to hdfs rather to local fs and then copying over.
+   */
+  def writeSRDD(directoryPath : String): Unit = {
+    self.foreach(p => {
+      p.writeToNetCDF(p.datasetName, "/tmp/")
+      val conf = new Configuration()
+      val fs = FileSystem.get(new URI(directoryPath), conf)
+      FileUtil.copy(new File("/tmp/" + p.datasetName), fs, new Path(directoryPath), true, conf)
+    })
+  }
+
+}
+
+object SRDDFunctions {
+
+  /** Implicit conversion from an RDD of SciDatasets to
+   *  RDDFunctions of SciDatasets
+   */
+  implicit def fromRDD(rdd: RDD[SciDataset]): SRDDFunctions = new SRDDFunctions(rdd)
+}

--- a/src/main/scala/org/dia/core/SciDataset.scala
+++ b/src/main/scala/org/dia/core/SciDataset.scala
@@ -17,11 +17,13 @@
  */
 package org.dia.core
 
+import java.util
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import ucar.nc2.Attribute
-import ucar.nc2.dataset
+import ucar.ma2.{Array, DataType}
+import ucar.nc2.{dataset, Attribute, NetcdfFileWriter}
 
 import org.dia.utils.NetCDFUtils
 
@@ -29,25 +31,48 @@ import org.dia.utils.NetCDFUtils
  * Dataset is a logical container for variable arrays.
  * A NetcdfDataset wraps a LinkedHashMap of variables and
  * a LinkedHashMap of attributes.
+ *
+ * The LinkedHashMap preserves insertion order for iteration purposes.
  */
 class SciDataset(val variables: mutable.LinkedHashMap[String, Variable],
-                 val attributes: mutable.LinkedHashMap[String, String]) extends Serializable{
+                 val attributes: mutable.LinkedHashMap[String, String],
+                 var datasetName: String) extends Serializable{
 
-  def this(vars : Traversable[(String, Variable)], attr : Traversable[(String, String)]) {
+  def this(vars : Traversable[(String, Variable)], attr : Traversable[(String, String)], datasetName : String) {
     this(new mutable.LinkedHashMap[String, Variable] ++= vars,
-         new mutable.LinkedHashMap[String, String] ++= attr)
+         new mutable.LinkedHashMap[String, String] ++= attr,
+         datasetName)
   }
 
-  def this(vars : Iterable[ucar.nc2.Variable], attr : Iterable[Attribute]) {
-    this(vars.map(p => (p.getFullName, new Variable(p))), attr.map(p => NetCDFUtils.convertAttribute(p)))
+  def this(vars : Iterable[ucar.nc2.Variable], attr : Iterable[Attribute], datasetName : String) {
+    this(vars.map(p => (p.getFullName, new Variable(p))),
+         attr.map(p => NetCDFUtils.convertAttribute(p)),
+         datasetName)
   }
 
   def this(nvar: dataset.NetcdfDataset) {
-    this(nvar.getVariables.asScala, nvar.getGlobalAttributes.asScala)
+    this(nvar.getVariables.asScala, nvar.getGlobalAttributes.asScala, nvar.getLocation.split("/").last)
   }
 
   def this(nvar: dataset.NetcdfDataset, vars: List[String]) {
-    this(vars.map(vr => nvar.findVariable(vr)), nvar.getGlobalAttributes.asScala)
+    this(vars.map(vr => nvar.findVariable(vr)), nvar.getGlobalAttributes.asScala, nvar.getLocation.split("/").last)
+  }
+
+  /**
+   * Extract all the dimension names from the variables
+   * Convert them into a string representation e.g.
+   *
+   * row(400), cols(1440)
+   *
+   * Flattens all the dimensions amongst the variables
+   * and keep the distinct dimensions.
+   */
+  def globalDimensions() : List[String] = {
+    variables.valuesIterator.map(variable =>
+      variable.dims.map({
+        case(dimName, length) => dimName + "(" + length + ")"
+      })
+    ).flatten.toList.distinct
   }
 
   /**
@@ -68,6 +93,10 @@ class SciDataset(val variables: mutable.LinkedHashMap[String, Variable],
     for (v <- variables) this.variables += ((v.name, v))
   }
 
+  def setName(newName : String): SciDataset = {
+    datasetName = newName
+    this
+  }
   /**
    * Access variables.
    * In Python's netcdf Dataset, variables can be accessed as
@@ -97,27 +126,62 @@ class SciDataset(val variables: mutable.LinkedHashMap[String, Variable],
   def attr(key: String): String = attributes(key)
 
   /**
+   * Writes the contents of SciDataset to a NetcdfFile.
+   *
+   * @param name Optional : The name of the netcdf file. If no name is specified, then
+   *             the current datasetName is used. Note that the function does not
+   *             append ".nc" by default and so must be included in the name.
+   * @param path Optional : The directory where this file will be written to.
+   *             By default it is written to the current directory.
+   */
+  def writeToNetCDF(name: String = datasetName, path: String = ""): Unit = {
+    val writer = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3, path + name, null)
+    val netcdfKeyValue = variables.map {
+      case (key, variable) =>
+        val dims = new util.ArrayList[ucar.nc2.Dimension]()
+        for ((dimName, length) <- variable.dims) {
+          val newDim = writer.addDimension(null, dimName, length)
+          dims.add(newDim)
+        }
+        val varT = writer.addVariable(null, key, ucar.ma2.DataType.FLOAT, dims)
+        varT.addAll(variable.attributes.map(p => new Attribute(p._1, p._2)).asJava)
+        val dataOut = Array.factory(DataType.DOUBLE, variable.shape(), variable.data())
+        (varT, dataOut)
+    }
+    for ((key, attribute) <- attributes) {
+      writer.addGroupAttribute(null, new Attribute(key, attribute))
+    }
+
+    writer.create()
+    for ((variable, array) <- netcdfKeyValue) writer.write(variable, array)
+    writer.close()
+  }
+
+  /**
    * Creates a clone of the variable
    *
    * @return
    */
-  def copy(): SciDataset = new SciDataset(variables.clone(), attributes.clone())
+  def copy(): SciDataset = new SciDataset(variables.clone(), attributes.clone(), datasetName)
 
   override def toString: String = {
-    val header = "root group ...\n"
-    val variableString = variables.map({case (str, varb) => varb.dataType + " " + str})
+    val header = datasetName + "\nroot group ...\n"
+    val dimensionString = "\tdimensions(sizes): " + globalDimensions().toString + "\n"
+    val variableString = variables.map({case (str, varb) => varb.dataType + " " + str + varb.dims.keys.toList})
     val footer = "\tvariables: " + variableString + "\n"
     val body = new StringBuilder()
     body.append(header)
     for ((k, v) <- attributes) {
       body.append("\t" + k + ": " + v + "\n")
     }
-    body.append(footer.replaceAll("(ArrayBuffer|\\(|\\))", ""))
+    body.append(dimensionString.replace("List", ""))
+    body.append(footer.replaceAll("(ArrayBuffer|List)", ""))
     body.toString()
   }
 
   override def equals(any: Any): Boolean = {
     val dataset = any.asInstanceOf[SciDataset]
+    dataset.datasetName == this.datasetName &&
     dataset.attributes == this.attributes &&
     dataset.variables == this.variables
   }

--- a/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
+++ b/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dia.core
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+
+import org.dia.core.SRDDFunctions._
+import org.dia.testenv.SparkTestConstants
+import org.dia.utils.NetCDFUtils
+
+class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
+
+  val netcdfDataset = NetCDFUtils.loadNetCDFDataSet("src/test/resources/Netcdf/nc_3B42_daily.2008.01.02.7.bin.nc")
+  val directoryString = "src/test/resources/Output/"
+  val directory = new java.io.File(directoryString)
+
+  override def beforeEach {
+    FileUtils.cleanDirectory(directory)
+  }
+
+  override def afterEach {
+    FileUtils.cleanDirectory(directory)
+  }
+
+  test("testWriteSRDD") {
+    val Dataset = new SciDataset(netcdfDataset)
+    val someRDD = SparkTestConstants.sc.sparkContext.parallelize(0 until 10)
+    someRDD.map(p => {
+      Dataset.setName("AnotherFile_" + p + ".nc")
+    }).writeSRDD(directoryString)
+
+    val fileCount = directory.listFiles.count(p => p.getName.charAt(0) != '.')
+    assert(fileCount == 10)
+
+  }
+
+}

--- a/src/test/scala/org/dia/core/SciDatasetTest.scala
+++ b/src/test/scala/org/dia/core/SciDatasetTest.scala
@@ -17,14 +17,18 @@
  */
 package org.dia.core
 
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import org.dia.utils.NetCDFUtils
 
-class SciDatasetTest extends FunSuite {
+class SciDatasetTest extends FunSuite with BeforeAndAfter{
 
   val netcdfDataset = NetCDFUtils.loadNetCDFDataSet("src/test/resources/Netcdf/nc_3B42_daily.2008.01.02.7.bin.nc")
-  val Dataset = new SciDataset(netcdfDataset)
+  var Dataset : SciDataset = _
+
+  before {
+    Dataset = new SciDataset(netcdfDataset)
+  }
 
   test("testCopy") {
     val copy = Dataset.copy()
@@ -32,7 +36,7 @@ class SciDatasetTest extends FunSuite {
   }
 
   test("testAttributes") {
-    val aerosolAttr = Dataset.attr("FF_GLOBAL\\.Server")
+    val aerosolAttr = Dataset.attr("FF_GLOBAL.Server")
     assert(aerosolAttr == "DODS FreeFrom based on FFND release 4.2.3")
   }
 
@@ -56,11 +60,26 @@ class SciDatasetTest extends FunSuite {
   }
 
   test("testToString") {
-    val string = "root group ...\n" +
-                 "\tFF_GLOBAL\\.Server: DODS FreeFrom based on FFND release 4.2.3\n" +
+    val string = "nc_3B42_daily.2008.01.02.7.bin.nc\n" +
+                 "root group ...\n" +
+                 "\tFF_GLOBAL.Server: DODS FreeFrom based on FFND release 4.2.3\n" +
                  "\t_CoordSysBuilder: ucar.nc2.dataset.conv.DefaultConvention\n" +
-                 "\tGreeting: Hi Five!\n" +
-                 "\tvariables: float data\n"
+                 "\tdimensions(sizes): (rows(400), cols(1440))\n" +
+                 "\tvariables: (float data(rows, cols))\n"
     assert(Dataset.toString == string)
   }
+
+  test("globalDimensions") {
+    val dimensions = Dataset.globalDimensions()
+    val dimensionsCheck = List("rows(400)", "cols(1440)")
+    assert(dimensions == dimensionsCheck)
+  }
+
+  test("writeDataset") {
+    val name = Dataset.datasetName
+    Dataset.writeToNetCDF()
+    val newDataset = new SciDataset(NetCDFUtils.loadNetCDFDataSet(name))
+    assert(newDataset == Dataset)
+  }
+
 }

--- a/src/test/scala/org/dia/core/VariableTest.scala
+++ b/src/test/scala/org/dia/core/VariableTest.scala
@@ -71,7 +71,7 @@ class VariableTest extends FunSuite {
   }
 
   test("testToString") {
-    val string = "float tas\n" +
+    val string = "float tas(time, lat, lon)\n" +
                 "\tcomment: Created using NCL code CCSM_atmm_2cf.ncl on\n" +
                 " machine eagle163s\n" +
                 "\tmissing_value: 1.0E20\n" +


### PR DESCRIPTION
This addresses issue #106

The key function here is SciDataset.write(name, path) which is used to write the contents
of the SciDataset to a Netcdf file.

The name parameter is an optional parameter. If no name is specified, then
the current datasetName is used. Note that the function does not
append ".nc" by default and so must be included in the name.

The path parameter is an optional parameter.
It points to the directory where this file will be written to.
By default it is written to the current directory.

Other changes :
SciDataset.scala
SciDataset has a datasetName member variable that indicates the name of the file it was loaded from.
SciDataset also has a globalDimensions function.
globalDimensions() gives you a list of strings which indicate the dimensions and their length
i.e. List("row(400)", "col(1440)")
The toString function in SciDataset also includes the global dimensions.

Variable.scala
Variable now has a member LinkedHashMap that records the dimension name and the corresponding value length as a key value pair.

NetcdfUtils.scala
The conversion function convertMa2Arrayto1dJavaArray() checks for the
data type stored in the Ma2Array using case statements. It converts the array to a Double array.

Future work :
Being able to write the SciDataset to HDFS rather than just the local file system.
