### PR TITLE
[SCISPARK 120] Slice for to 2d array so we can use rows() and cols()

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ scalaVersion := "2.10.6"
 
 scalacOptions := Seq("-feature", "-deprecation")
 
-mainClass in Compile := Some("org.dia.algorithms.pdfclustering.PDFClusteringAnomalies")
+mainClass in Compile := Some("org.dia.algorithms.mcc.MainNetcdfDFSMCC")
 
 resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
+++ b/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
@@ -74,9 +74,7 @@ object MainNetcdfDFSMCC {
       val source = p.metaData("SOURCE").split("/").last.split("_")(1)
       val FrameID = source.toInt
       p.insertDictionary(("FRAME", FrameID.toString))
-      val row = p.shape(1)
-      val col = p.shape(2)
-      p.insertVar(p.varInUse, p.tensor.reshape(Array(row, col)))
+      p.insertVar(p.varInUse, p()(0))
       p
     })
 

--- a/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
+++ b/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
@@ -74,6 +74,9 @@ object MainNetcdfDFSMCC {
       val source = p.metaData("SOURCE").split("/").last.split("_")(1)
       val FrameID = source.toInt
       p.insertDictionary(("FRAME", FrameID.toString))
+      val row = p.shape(1)
+      val col = p.shape(2)
+      p.insertVar(p.varInUse, p.tensor.reshape(Array(row, col)))
       p
     })
 

--- a/src/main/scala/org/dia/algorithms/pdfclustering/MainCompute.scala
+++ b/src/main/scala/org/dia/algorithms/pdfclustering/MainCompute.scala
@@ -160,7 +160,7 @@ object MainCompute {
       while (idx < numLats) {
         jdx = 0
         while (jdx < numLongs) {
-          val elem = ((lats(idx), longs(jdx)), prec(idx, jdx))
+          val elem = ((lats(idx, 0), longs(jdx, 0)), prec(idx, jdx))
           precPerLatLon += elem
           jdx += 1
         }

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -142,6 +142,8 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
 
   def cols: Int = tensor.cols
 
+  def apply(index: Int) : BreezeTensor = tensor(index, ::).inner.toDenseMatrix
+
   def apply: BreezeTensor = this
 
   def apply(ranges: (Int, Int)*): BreezeTensor = {

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -164,6 +164,8 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
   def apply(indexes: Int*): Double = tensor.getDouble(indexes: _*)
 
+  def apply(index: Int) : Nd4jTensor = new Nd4jTensor(tensor.get(NDArrayIndex.point(index)))
+
   def data: Array[Double] = tensor.data.asDouble()
 
   /**

--- a/src/main/scala/org/dia/tensors/SliceableArray.scala
+++ b/src/main/scala/org/dia/tensors/SliceableArray.scala
@@ -36,4 +36,6 @@ trait SliceableArray {
 
   def apply(indexes: Int*): Double
 
+  def apply(index: Int) : T
+
 }

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -234,4 +234,18 @@ class BasicTensorTest extends FunSuite {
     val zeroSkew = new Nd4jTensor(Nd4j.zeros(3, 3))
     assert(skw == zeroSkew)
   }
+
+  test("applySingleIndex") {
+    val sample = (0d to 27d by 1d).toArray
+    val squareSample = (0d to 8d by 1d).toArray
+    val cube = Nd4j.create(sample, Array(3, 3, 3))
+    val cubeTensor = new Nd4jTensor(cube)
+    val square = Nd4j.create(squareSample, Array(3, 3))
+    val squareTensor = new Nd4jTensor(square)
+    val slicedSquare = cubeTensor(0)
+
+    val zeroSkew = new Nd4jTensor(Nd4j.zeros(3, 3))
+    assert(squareTensor == slicedSquare)
+  }
+
 }


### PR DESCRIPTION
Addresses issue #120 

Originally the array has shape (1, 4125, 1238).
However, we can't call rows() or cols() on that array since it is not 2d.

The error came up due to recent upgrades we have made to our dependency on our array libraries.

The solution is to reshape the arrays from (1, 4125, 1238) to (4125, 1238).
It's sole effect is on the shape information and not on how the data is organized.
