### PR TITLE
[SCISPARK 115] Fix time series bug

### DIFF
--- a/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
+++ b/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
@@ -43,7 +43,7 @@ object MainNetcdfDFSMCC {
      * args(4) - local path to files
      *
      */
-    val masterURL = if (args.isEmpty) "local[2]" else args(0)
+    val masterURL = if (args.isEmpty) "local[*]" else args(0)
     val partCount = if (args.length <= 1) 2 else args(1).toInt
     val dimension = if (args.length <= 2) (20, 20) else (args(2).toInt, args(2).toInt)
     val variable = if (args.length <= 3) "ch4" else args(3)
@@ -94,8 +94,8 @@ object MainNetcdfDFSMCC {
     val filtered = labeled.map(p => p(variable) <= 241.0)
     val consecFrames = filtered.sortBy(p => p.metaData("FRAME").toInt)
                                .zipWithIndex()
-                               .flatMap({ case(sciT, indx) => List((indx, sciT), (indx + 1, sciT))})
-                               .groupByKey()
+                               .flatMap({ case(sciT, indx) => List((indx, List(sciT)), (indx + 1, List(sciT)))})
+                               .reduceByKey(_ ++ _)
                                .filter({case (_, sciTs) => sciTs.size == 2})
                                .map({ case(_, sciTs) => sciTs.toList.sortBy(p => p.metaData("FRAME").toInt)})
                                .map(sciTs => (sciTs(0), sciTs(1)))

--- a/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
+++ b/src/main/scala/org/dia/algorithms/mcc/MainNetcdfDFSMCC.scala
@@ -92,13 +92,13 @@ object MainNetcdfDFSMCC {
      * of frames.
      */
     val filtered = labeled.map(p => p(variable) <= 241.0)
-    val consecFrames = filtered.flatMap(p => {
-      List((p.metaData("FRAME").toInt, p), (p.metaData("FRAME").toInt + 1, p))
-    }).groupBy(_._1)
-      .map(p => p._2.map(e => e._2).toList)
-      .filter(p => p.size > 1)
-      .map(p => p.sortBy(_.metaData("FRAME").toInt))
-      .map(p => (p(0), p(1)))
+    val consecFrames = filtered.sortBy(p => p.metaData("FRAME").toInt)
+                               .zipWithIndex()
+                               .flatMap({ case(sciT, indx) => List((indx, sciT), (indx + 1, sciT))})
+                               .groupByKey()
+                               .filter({case (_, sciTs) => sciTs.size == 2})
+                               .map({ case(_, sciTs) => sciTs.toList.sortBy(p => p.metaData("FRAME").toInt)})
+                               .map(sciTs => (sciTs(0), sciTs(1)))
 
     val debug = consecFrames.collect()
     /**


### PR DESCRIPTION
The fix does four things ->
1. sorts the RDD by the SciDataset frame number (the date)
2. Zips the RDD  -> each SciDataset is paired with it's index in the sorted RDD
3. Use reduceByKey rather than groupByKey
   See this article here for an explanation why : https://databricks.gitbooks.io/databricks-spark-knowledge-base/content/best_practices/prefer_reducebykey_over_groupbykey.html
4. Also added some extra naming i.e. using "SciTs" instead of "p" in lambda expressions.

To verify this PR you should see number of vertices as 1004 and number of edges as 853.
These are the original numbers.
The fix will not change the results because our example data does not span more than a day.
