### PR TITLE
[SCISPARK 127] Prepend 1 to single dimension nd4j arrays

### DIFF
--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -269,7 +269,7 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
   private implicit def AbstractConvert(array: AbstractTensor): Nd4jTensor = array.asInstanceOf[Nd4jTensor]
 }
 
-object Nd4jTensorUtils {
+private object Nd4jTensorUtils {
 
   def processShape(shape: Array[Int]) : Array[Int] = {
     shape.length match {

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -34,8 +34,12 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
   val shape = tensor.shape
   var mask = 0.0
 
+  def this(array: Array[Double], shape: Array[Int]) {
+   this(Nd4j.create(array, Nd4jTensorUtils.processShape(shape)))
+  }
+
   def this(shapePair: (Array[Double], Array[Int])) {
-    this(Nd4j.create(shapePair._1, shapePair._2))
+    this(shapePair._1, shapePair._2)
   }
 
   def this(loadFunc: () => (Array[Double], Array[Int])) {
@@ -263,4 +267,14 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
   def copy: Nd4jTensor = new Nd4jTensor(this.tensor.dup())
 
   private implicit def AbstractConvert(array: AbstractTensor): Nd4jTensor = array.asInstanceOf[Nd4jTensor]
+}
+
+object Nd4jTensorUtils {
+
+  def processShape(shape: Array[Int]) : Array[Int] = {
+    shape.length match {
+      case 1 => Array(1) ++ shape
+      case _ => shape
+    }
+  }
 }

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -248,4 +248,9 @@ class BasicTensorTest extends FunSuite {
     assert(squareTensor == slicedSquare)
   }
 
+  test("Nd4jSingleDimension") {
+    val squareSample = (0d to 4d by 1d).toArray
+    val tensor = new Nd4jTensor(squareSample, Array(4))
+    assert(tensor.shape.toList == List(1, 4))
+  }
 }


### PR DESCRIPTION
Addresses issue #127 

Nd4j doesn't represent single dimension arrays having a shape of 1 size.
Rather it treats these arrays having a shape of (1, sizeOfDimension).

Netcdf files however do represent shapes having a single dimension.

The proposed fix checks the size of the shape when construction Nd4jTensors.
If the shape is of size 1, then we prepend a 1 to the array. Otherwise we leave it alone.

@kwhitehall @sujen1412 @BrianWilson1 thoughts?
