### PR TITLE
[SCISPARK] Support multiple spark and scala versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,19 @@ dist: trusty
 
 # 2. Choose language and target JDKs for parallel  builds
 language: scala
-scala:
-  - 2.10.6
+
+# 3. Versioning matrix.
+#    We test two versions of spark 1.6.0 and 2.0.0
+#    We test scala 2.10.6 on both and 2.11.2 on Spark 2.0.0
+matrix:
+  include:
+    - scala: 2.10.6
+      env:
+        - SPARK_VERSION=1.6.0 SCALA_VERSION=2.10.6
+        - SPARK_VERSION=2.0.0 SCALA_VERSION=2.10.6
+    - scala: 2.11.2
+      env:
+        - SPARK_VERSION=2.0.0 SCALA_VERSION=2.11.2
 
 # 3. Setup cache directory for SBT
 cache:
@@ -44,8 +55,8 @@ install:
 # 6. Run maven sbt compile, test, and generate coverage reports
 script:
   - sbt clean
-  - sbt compile
-  - sbt coverage test
+  - sbt -Dscala.version=$SCALA_VERSION -Dspark.version=$SPARK_VERSION compile
+  - sbt -Dscala.version=$SCALA_VERSION -Dspark.version=$SPARK_VERSION coverage test
 
 # 7. Generate the coverageReport for coveralls
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - scala: 2.10.6
       env: SPARK_VERSION=1.6.0 SCALA_VERSION=2.10.6
     - scala: 2.10.6
-      env: SPARK_VERSION=1.6.0 SCALA_VERSION=2.10.6
+      env: SPARK_VERSION=2.0.0 SCALA_VERSION=2.10.6
     - scala: 2.11.2
       env: SPARK_VERSION=2.0.0 SCALA_VERSION=2.11.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,11 @@ language: scala
 matrix:
   include:
     - scala: 2.10.6
-      env:
-        global:
-          - SCALA_VERSION=2.10.6
-        matrix:
-          - SPARK_VERSION=1.6.0
-          - SPARK_VERSION=2.0.0
+      env: SPARK_VERSION=1.6.0 SCALA_VERSION=2.10.6
+    - scala: 2.10.6
+      env: SPARK_VERSION=1.6.0 SCALA_VERSION=2.10.6
     - scala: 2.11.2
-      env:
-        - SPARK_VERSION=2.0.0 SCALA_VERSION=2.11.2
+      env: SPARK_VERSION=2.0.0 SCALA_VERSION=2.11.2
 
 # 3. Setup cache directory for SBT
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,11 @@ matrix:
   include:
     - scala: 2.10.6
       env:
-        - SPARK_VERSION=1.6.0 SCALA_VERSION=2.10.6
-        - SPARK_VERSION=2.0.0 SCALA_VERSION=2.10.6
+        global:
+          - SCALA_VERSION=2.10.6
+        matrix:
+          - SPARK_VERSION=1.6.0
+          - SPARK_VERSION=2.0.0
     - scala: 2.11.2
       env:
         - SPARK_VERSION=2.0.0 SCALA_VERSION=2.11.2

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,19 @@
  */
 import sbt.Resolver
 
+val scalaVersionParameterOption = Option(System.getProperty("scala.version"))
+val sparkVersionParameterOption = Option(System.getProperty("spark.version"))
+
+val sversion = scalaVersionParameterOption match {
+  case Some(x) => x
+  case None => "2.11.2"
+}
+
+val sparkVersion = sparkVersionParameterOption match {
+  case Some(x) => x
+  case None => "2.0.0"
+}
+
 assemblyJarName in assembly := "SciSpark.jar"
 
 name := "SciSpark"
@@ -25,7 +38,8 @@ organization := "org.dia"
 
 version := "1.0"
 
-scalaVersion := "2.10.6"
+// Default is 2.10.6
+scalaVersion := sversion
 
 scalacOptions := Seq("-feature", "-deprecation")
 
@@ -63,9 +77,9 @@ test in assembly := {}
 classpathTypes += "maven-plugin"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" % "scalatest_2.10" % "3.0.0-M15",
-  "org.apache.spark" % "spark-core_2.10" % "1.6.0" exclude("org.slf4j", "slf4j-api"),
-  "org.apache.spark" % "spark-mllib_2.10" % "1.6.0",
+  "org.scalatest" %% "scalatest" % "3.0.0",
+  "org.apache.spark" %% "spark-core" % sparkVersion,
+  "org.apache.spark" %% "spark-mllib" % sparkVersion,
   // Math Libraries
   // "org.jblas" % "jblas" % "1.2.3",
   // other dependencies here
@@ -76,7 +90,7 @@ libraryDependencies ++= Seq(
   // Nd4j scala api with netlib-blas backend
   // "org.nd4j" % "nd4s_2.10" % "0.5.0",
   "org.nd4j" % "nd4j-native-platform" % "0.5.0",
-  "org.nd4j" % "nd4j-kryo_2.10" % "0.5.0",
+  "org.nd4j" %% "nd4j-kryo" % "0.5.0",
   "edu.ucar" % "opendap" % "4.6.0",
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.8.1",

--- a/src/main/scala/org/dia/core/SRDD.scala
+++ b/src/main/scala/org/dia/core/SRDD.scala
@@ -40,7 +40,7 @@ import org.dia.tensors.{AbstractTensor, TensorFactory}
  *
  */
 class SRDD[T: ClassTag](@transient var sc: SparkContext,
-                        @transient var deps: Seq[Dependency[_]]) extends RDD[T](sc, deps) with Logging {
+                        @transient var deps: Seq[Dependency[_]]) extends RDD[T](sc, deps) {
   val arrLib = sc.getLocalProperty(org.dia.Constants.ARRAY_LIB)
   var datasets: List[String] = null
   var varName: Seq[String] = Nil


### PR DESCRIPTION
This pull request enables SciSpark to compile for multiple versions of scala and spark.

We can pass the spark.version and scala.version property parameters like so :

sbt -Dspark.version=1.6.0 -Dscala.version=2.10.6 compile

If we do not pass these parameters explicitly then SciSpark by default will compile for Spark 2.0.0 and Scala 2.11.2.

I removed the scala version specifiers in each of the depedency names.
For example, spark-core_2.10 became spark-core.

We pick up the version from our scalaVersion variable by using the %% specifier.
%% tells sbt to pick the dependency version that is built for the currently used scala version.

Travis CI can also execute multiple builds to test against each version of scala/spark.
Right now we execute the following builds

spark=1.6.0 scala=2.10.6
spark=2.0.0 scala=2.10.6
spark=2.0.0 scala=2.11.2

Thoughts @kwhitehall @BrianWilson1 @chrismattmann @sujen1412 ?

A point about 2.11.2:

In some places (like MCCNode.scala and NetcdfDFSMCC.scala)
we use getOrElse and the 2.11.2 compiler will throw us a warning about using getOrElse.

I have not fixed those warnings as Sujen is working on that part of the code right now and I have communicated that to him. The code uses getOrElse to deal with option types, when it should be dealt with by using the match and case semantics. Furthermore, lets avoid using hashmaps of type [String, Any] to put in multiple types of objects in a hashmap (this can be done in python but not advised in scala/java).
