### PR TITLE
[SCISPARK 135] Fix Variable Broadcast test for appropriate shape

### DIFF
--- a/src/test/scala/org/dia/core/VariableTest.scala
+++ b/src/test/scala/org/dia/core/VariableTest.scala
@@ -343,7 +343,7 @@ class VariableTest extends FunSuite with BeforeAndAfterEach {
   }
 
   test("test Broadcast") {
-    val axis = Array(0)
+    val axis = Array(3, 4, 4)
     val solutionName = "broadcast(" + leftName + "," + axis.toList + ")"
     val solution = new Variable(solutionName, leftTensor.broadcast(axis))
     val leftOpRight = leftVar.broadcast(axis)


### PR DESCRIPTION
Adresses issue #135.
Not sure how the test passed in the original PR, but once other PR's were merged the error popped up.
Nd4j will throw an exception if you try to broadcast to a shape of 0.

In stead it makes more sense to broadcast a 4 x 4 array to a 3 x 4 x 4 array in tests.
This is what the above PR does.
All tests should pass.
