### PR TITLE
[SCISPARK 138] Resolve SciDataset hash map serialization issues

### DIFF
--- a/src/main/scala/org/dia/core/SciDataset.scala
+++ b/src/main/scala/org/dia/core/SciDataset.scala
@@ -34,13 +34,13 @@ import org.dia.utils.NetCDFUtils
  *
  * The LinkedHashMap preserves insertion order for iteration purposes.
  */
-class SciDataset(val variables: mutable.LinkedHashMap[String, Variable],
-                 val attributes: mutable.LinkedHashMap[String, String],
+class SciDataset(val variables: mutable.HashMap[String, Variable],
+                 val attributes: mutable.HashMap[String, String],
                  var datasetName: String) extends Serializable{
 
   def this(vars : Traversable[(String, Variable)], attr : Traversable[(String, String)], datasetName : String) {
-    this(new mutable.LinkedHashMap[String, Variable] ++= vars,
-         new mutable.LinkedHashMap[String, String] ++= attr,
+    this(mutable.HashMap[String, Variable]() ++= vars,
+         mutable.HashMap[String, String]() ++= attr,
          datasetName)
   }
 
@@ -167,7 +167,7 @@ class SciDataset(val variables: mutable.LinkedHashMap[String, Variable],
   override def toString: String = {
     val header = datasetName + "\nroot group ...\n"
     val dimensionString = "\tdimensions(sizes): " + globalDimensions().toString + "\n"
-    val variableString = variables.map({case (str, varb) => varb.dataType + " " + str + varb.dims.keys.toList})
+    val variableString = variables.map({case (str, varb) => varb.dataType + " " + str + varb.dims.map(_._1)})
     val footer = "\tvariables: " + variableString + "\n"
     val body = new StringBuilder()
     body.append(header)

--- a/src/main/scala/org/dia/core/Variable.scala
+++ b/src/main/scala/org/dia/core/Variable.scala
@@ -49,47 +49,32 @@ import org.dia.utils.NetCDFUtils
 class Variable(var name: String,
                val dataType: String,
                val array: AbstractTensor,
-               val attributes: mutable.LinkedHashMap[String, String],
-               val dims: mutable.LinkedHashMap[String, Int]) extends Serializable {
+               val attributes: mutable.HashMap[String, String],
+               val dims: List[(String, Int)]) extends Serializable {
 
   val LOG = org.slf4j.LoggerFactory.getLogger(this.getClass)
 
   def this(name: String,
            dataType: String,
-           array: AbstractTensor,
-           attr: TraversableOnce[(String, String)],
-           dims: mutable.LinkedHashMap[String, Int]) {
-    this(name, dataType, array, new mutable.LinkedHashMap[String, String] ++= attr, dims)
-  }
-
-  def this(name: String,
-           daaType: String,
-           array: AbstractTensor,
-           attr: java.util.List[Attribute],
-           dims: mutable.LinkedHashMap[String, Int]) {
-    this(name, daaType, array, attr.asScala.map(p => NetCDFUtils.convertAttribute(p)), dims)
-  }
-
-  def this(name: String,
-           dataType: String,
            array: Array[Double],
            shape: Array[Int],
-           attr: java.util.List[Attribute],
-           dims: TraversableOnce[(String, Int)]) {
+           attr: Seq[(String, String)],
+           dims: List[(String, Int)]) {
     this(name,
          dataType,
-         new Nd4jTensor(array, if (shape.length > 1) shape else Array(1) ++ shape),
-         attr,
-         new mutable.LinkedHashMap[String, Int]() ++= dims)
+         new Nd4jTensor(array, shape),
+         mutable.HashMap[String, String]() ++= attr,
+         dims)
   }
 
 
   def this(name: String, nvar: ucar.nc2.Variable) {
-    this(name, nvar.getDataType.toString,
-      NetCDFUtils.getArrayFromVariable(nvar),
-      nvar.getShape,
-      nvar.getAttributes,
-      nvar.getDimensions.asScala.map(p => (p.getFullName, p.getLength)))
+    this(name,
+         nvar.getDataType.toString,
+         NetCDFUtils.getArrayFromVariable(nvar),
+         nvar.getShape,
+         nvar.getAttributes.asScala.map(p => NetCDFUtils.convertAttribute(p)),
+         nvar.getDimensions.asScala.map(p => (p.getFullName, p.getLength)).toList)
   }
 
   def this(nvar: ucar.nc2.Variable) {
@@ -100,8 +85,8 @@ class Variable(var name: String,
     this(name,
          "Double64",
          array,
-         new mutable.LinkedHashMap[String, String],
-         new mutable.LinkedHashMap[String, Int])
+         mutable.HashMap[String, String](),
+         List[(String, Int)]())
   }
 
   def this(array: AbstractTensor) {
@@ -316,37 +301,39 @@ class Variable(var name: String,
    *
    * @return
    */
-  def copy(): Variable = new Variable(name, dataType, array.copy, attributes.clone(), dims.clone())
+  def copy(): Variable = new Variable(name, dataType, array.copy, attributes.clone(), dims)
 
   override def clone(): AnyRef = this.copy()
 
   /**
    * It should print just the same or similar to how
    * variables are printed in Netcdf python.
+   * The attributes are printed in lexicographic order
    * e.g.
    *
    * float32 ch4(time, latitude, longitude)
    * comments: Unknown1 variable comment
-   * long_name: IR BT (add 75 to this value)
-   * units:
    * grid_name: grid01
    * grid_type: linear
    * level_description: Earth surface
-   * time_statistic: instantaneous
+   * long_name: IR BT (add 75 to this value)
    * missing_value: 330.0
+   * units:
+   * time_statistic: instantaneous
    * current shape = (1238, 4125)
    *
    */
   override def toString: String = {
-    val dimensionString = dims.keys.toString.replace("Set", "")
+    val dimensionString = "(" + dims.map(_._1).reduce((a, b) => a + ", " + b) + ")"
     val header = dataType + " " + name + dimensionString + "\n"
-    val footer = "current shape = " + shape().toList + "\n"
+    val shapeString = shape().map(_.toString).reduce((a, b) => a + ", " + b)
+    val footer = "current shape = (" + shapeString + ")\n"
     val body = new StringBuilder()
     body.append(header)
-    for ((k, v) <- attributes) {
+    for ((k, v) <- attributes.toSeq.sorted) {
       body.append("\t" + k + ": " + v + "\n")
     }
-    body.append(footer.replace("List", ""))
+    body.append(footer)
     body.toString()
   }
 
@@ -364,9 +351,9 @@ class Variable(var name: String,
     val newName = "(" + this.name + " " + op + " " + otherName + ")"
     op match {
       case "+" | "-" | "/" | "*" | "**" =>
-        new Variable(newName, dataType, abstractTensor, attributes.clone, dims.clone)
+        new Variable(newName, dataType, abstractTensor, attributes.clone, dims)
       case "<" | ">" | "<=" | ">=" | "!=" | ":=" =>
-        new Variable(newName, dataType, abstractTensor, attributes.clone, dims.clone)
+        new Variable(newName, dataType, abstractTensor, attributes.clone, dims)
       case "+=" | "-=" | "/=" | "*=" =>
         this.name = newName
         this
@@ -376,12 +363,12 @@ class Variable(var name: String,
 
   private def varStatOp(abstractTensor: AbstractTensor, op: String, param: String): Variable = {
     val newName = op + "(" + this.name + "," + param + ")"
-    new Variable(newName, dataType, abstractTensor, attributes.clone, dims.clone)
+    new Variable(newName, dataType, abstractTensor, attributes.clone, dims)
   }
 
   private def arrayOp(abstractTensor: AbstractTensor, op: String) = {
     val newName = this.name + "[" + op + "]"
-    new Variable(newName, dataType, abstractTensor, attributes.clone, dims.clone)
+    new Variable(newName, dataType, abstractTensor, attributes.clone, dims)
   }
 
 }

--- a/src/test/scala/org/dia/core/SRDDTest.scala
+++ b/src/test/scala/org/dia/core/SRDDTest.scala
@@ -434,10 +434,10 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
 
   test("SRDDDatasetSerializationTest") {
     val netcdfDataset = NetCDFUtils.loadNetCDFDataSet("src/test/resources/Netcdf/nc_3B42_daily.2008.01.02.7.bin.nc")
-    var Dataset : SciDataset = new SciDataset(netcdfDataset)
+    val Dataset = new SciDataset(netcdfDataset)
     val sRDD = sc.parallelize(0 to 5).map(p => Dataset)
-    val sRDD_Dataset = sRDD.collect()(0)
-    assert(Dataset == sRDD_Dataset)
+    val sRDDDataset = sRDD.collect()(0)
+    assert(Dataset == sRDDDataset)
   }
 
 }

--- a/src/test/scala/org/dia/core/SRDDTest.scala
+++ b/src/test/scala/org/dia/core/SRDDTest.scala
@@ -432,4 +432,12 @@ class SRDDTest extends FunSuite with BeforeAndAfter {
     assert(true)
   }
 
+  test("SRDDDatasetSerializationTest") {
+    val netcdfDataset = NetCDFUtils.loadNetCDFDataSet("src/test/resources/Netcdf/nc_3B42_daily.2008.01.02.7.bin.nc")
+    var Dataset : SciDataset = new SciDataset(netcdfDataset)
+    val sRDD = sc.parallelize(0 to 5).map(p => Dataset)
+    val sRDD_Dataset = sRDD.collect()(0)
+    assert(Dataset == sRDD_Dataset)
+  }
+
 }

--- a/src/test/scala/org/dia/core/VariableTest.scala
+++ b/src/test/scala/org/dia/core/VariableTest.scala
@@ -96,7 +96,7 @@ class VariableTest extends FunSuite with BeforeAndAfterEach {
 
   test("test Dims") {
     val dims = dataVar.getDimensions.asScala.map(p => (p.getFullName, p.getLength))
-    val varDims = variable.dims
+    val varDims = variable.dims.toMap
     for((dim, len) <- dims) assert(varDims(dim) == len)
   }
 
@@ -114,19 +114,19 @@ class VariableTest extends FunSuite with BeforeAndAfterEach {
 
   test("testToString") {
     val string = "float tas(time, lat, lon)\n" +
+      "\t_FillValue: 1.0E20\n" +
+      "\tcell_method: time: mean\n" +
+      "\tcell_methods: time: mean (interval: 1 month)\n" +
       "\tcomment: Created using NCL code CCSM_atmm_2cf.ncl on\n" +
       " machine eagle163s\n" +
-      "\tmissing_value: 1.0E20\n" +
-      "\t_FillValue: 1.0E20\n" +
-      "\tcell_methods: time: mean (interval: 1 month)\n" +
-      "\thistory: Added height coordinate\n" +
       "\tcoordinates: height\n" +
-      "\toriginal_units: K\n" +
+      "\thistory: Added height coordinate\n" +
+      "\tlong_name: air_temperature\n" +
+      "\tmissing_value: 1.0E20\n" +
       "\toriginal_name: TREFHT\n" +
+      "\toriginal_units: K\n" +
       "\tstandard_name: air_temperature\n" +
       "\tunits: K\n" +
-      "\tlong_name: air_temperature\n" +
-      "\tcell_method: time: mean\n" +
       "current shape = (1, 128, 256)\n"
     assert(variable.toString == string)
   }


### PR DESCRIPTION
I am removing the LinkedHashMap from SciDataset and Variable
so they can be properly serialized.

Instead, lets use a normal HashMap for the attributes and a List of (String, Int) pairs for the dimensions.

The key property of the LinkedHashMap which we use is insertion order on traversals of the map.
After having a chat with @BrianWilson1 he said we could do without it.

We do want to preserve insertion order for the dimensions and since they're usually small, I chose to use a List object.

Finally I added a test in SRDDTest which checks for proper serialization of the SciDataset class.

addresses issue #138 
