### PR TITLE
[SCISPARK 7] (re)partition By Space

### DIFF
--- a/src/main/scala/org/dia/core/SRDDFunctions.scala
+++ b/src/main/scala/org/dia/core/SRDDFunctions.scala
@@ -159,9 +159,9 @@ class SRDDFunctions(self: RDD[SciDataset]) extends Serializable {
       })
   }
 
-  def splitBySubsets(varName: String,
-                     keyFunc: SciDataset => Int,
-                     subsetShape: Int*): RDD[Variable] = {
+  def repartitionBySpace(varName: String,
+                         keyFunc: SciDataset => Int,
+                         subsetShape: Int*): RDD[Variable] = {
     val rangeKeyedRDD = splitTiles(varName, keyFunc, subsetShape: _*)
     stackTiles(rangeKeyedRDD)
   }

--- a/src/main/scala/org/dia/core/SciDataset.scala
+++ b/src/main/scala/org/dia/core/SciDataset.scala
@@ -162,11 +162,21 @@ class SciDataset(val variables: mutable.HashMap[String, Variable],
   }
 
   /**
-   * Creates a clone of the variable
+   * Creates a clone of the SciDataset
    *
    * @return
    */
-  def copy(): SciDataset = new SciDataset(variables.clone(), attributes.clone(), datasetName)
+  def copy(): SciDataset = {
+    /**
+     * Hashmaps by default in scala do not do a deep clone.
+     * Cloning the variable hashmap only copies the references
+     * not the actual objects.
+     *
+     * Instead each variable in the hashmap is cloned.
+     */
+    val clonedVariables = variables.map({case (name, variable) => (name, variable.copy())})
+    new SciDataset(clonedVariables, attributes.clone.toSeq, datasetName)
+  }
 
   override def toString: String = {
     val header = datasetName + "\nroot group ...\n"

--- a/src/main/scala/org/dia/core/SciDataset.scala
+++ b/src/main/scala/org/dia/core/SciDataset.scala
@@ -58,6 +58,10 @@ class SciDataset(val variables: mutable.HashMap[String, Variable],
     this(vars.map(vr => nvar.findVariable(vr)), nvar.getGlobalAttributes.asScala, nvar.getLocation.split("/").last)
   }
 
+  def this(datasetName : String) {
+    this(mutable.HashMap[String, Variable](), mutable.HashMap[String, String](), datasetName)
+  }
+
   /**
    * Extract all the dimension names from the variables
    * Convert them into a string representation e.g.

--- a/src/main/scala/org/dia/core/Variable.scala
+++ b/src/main/scala/org/dia/core/Variable.scala
@@ -81,11 +81,17 @@ class Variable(var name: String,
     this(nvar.getFullName, nvar)
   }
 
+  def this(name: String, array: AbstractTensor, dims: List[(String, Int)]) {
+    this(name,
+      "Double64",
+      array,
+      mutable.HashMap[String, String](),
+      dims)
+  }
+
   def this(name: String, array: AbstractTensor) {
     this(name,
-         "Double64",
          array,
-         mutable.HashMap[String, String](),
          List[(String, Int)]())
   }
 
@@ -303,7 +309,7 @@ class Variable(var name: String,
    */
   def copy(): Variable = new Variable(name, dataType, array.copy, attributes.clone(), dims)
 
-  override def clone(): AnyRef = this.copy()
+  override def clone(): AnyRef = new Variable(name, dataType, array.copy, attributes.clone(), dims)
 
   /**
    * It should print just the same or similar to how

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -102,7 +102,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
    * @param array the new array to stack on
    * @return the stacked array
    */
-  def stack(array : AbstractTensor) : T
+  def stack(array : AbstractTensor*) : T
 
    /**
    * Returns the data dimensions
@@ -123,10 +123,12 @@ trait AbstractTensor extends Serializable with SliceableArray {
   def toString: String
 
   /**
+   * It will be called when checking equality against
+   * different implementations of AbstractTensor.
    * Due to properties of Doubles, the equals method
    * utilizes the percent error rather than checking absolute equality.
    * The threshold for percent error is if it is greater than 0.5% or .005.
-   * @param any
+   * @param any the object to compare to
    * @return
    */
   override def equals(any: Any): Boolean = {
@@ -138,7 +140,7 @@ trait AbstractTensor extends Serializable with SliceableArray {
 
     val thisData = this.data
     val otherData = array.data
-    for(index <- 0 to thisData.length - 1) {
+    for(index <- thisData.indices) {
       val left = thisData(index)
       val right = otherData(index)
       if(left != 0.0 && right == 0.0) {

--- a/src/main/scala/org/dia/tensors/AbstractTensor.scala
+++ b/src/main/scala/org/dia/tensors/AbstractTensor.scala
@@ -92,6 +92,18 @@ trait AbstractTensor extends Serializable with SliceableArray {
    */
   def data: Array[Double]
 
+  /**
+   * Stacks the current array ontop of the input array
+   * in row ordered fashion
+   * [this.array, array]
+   *
+   * The resulting array will have shape (2, originalShape)
+   *
+   * @param array the new array to stack on
+   * @return the stacked array
+   */
+  def stack(array : AbstractTensor) : T
+
    /**
    * Returns the data dimensions
    *

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -154,6 +154,9 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
     tensor(indexes(0), indexes(1))
   }
 
+  def stack(array: AbstractTensor) : BreezeTensor = {
+    throw new Exception("This method in BreezeTensor has not been implemented yet")
+  }
   /**
    * Utility Operations
    */

--- a/src/main/scala/org/dia/tensors/BreezeTensor.scala
+++ b/src/main/scala/org/dia/tensors/BreezeTensor.scala
@@ -154,7 +154,7 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
     tensor(indexes(0), indexes(1))
   }
 
-  def stack(array: AbstractTensor) : BreezeTensor = {
+  def stack(array: AbstractTensor*) : BreezeTensor = {
     throw new Exception("This method in BreezeTensor has not been implemented yet")
   }
   /**
@@ -213,6 +213,14 @@ class BreezeTensor(val tensor: DenseMatrix[Double]) extends AbstractTensor {
 
   def copy: BreezeTensor = tensor.copy
 
+  override def equals(obj: Any): Boolean = {
+    obj match {
+    case breeze: BreezeTensor => this.tensor == breeze.tensor
+    case _ => super.equals(obj)
+    }
+  }
+
+  override def hashCode(): Int = super.hashCode()
   /**
    * Due to implicit conversions we can do operations on BreezeTensors and DenseMatrix
    */

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -172,7 +172,18 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
   def data: Array[Double] = tensor.data.asDouble()
 
-  def stack(array: AbstractTensor*) : Nd4jTensor = Nd4j.hstack(this.tensor, array)
+  /**
+   * Joins a sequence of arrays along the first axis
+   *
+   * @param arrays the arrays to stack on
+   * @return the resulting array
+   */
+  def stack(arrays: AbstractTensor*) : Nd4jTensor = {
+    val listOfTensors = List(this.tensor) ++ arrays.map(_.tensor)
+    val newShape = Array(arrays.length + 1) ++ this.shape
+    val stackedTensors = Nd4j.vstack(listOfTensors: _*).reshape(newShape: _*)
+    new Nd4jTensor(stackedTensors)
+  }
 
   /**
    * Utility Functions
@@ -267,6 +278,15 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
   def min: Double = tensor.minNumber.asInstanceOf[Double]
 
   def copy: Nd4jTensor = new Nd4jTensor(this.tensor.dup())
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case nd4j: Nd4jTensor => this.tensor == nd4j.tensor
+      case _ => super.equals(obj)
+    }
+  }
+
+  override def hashCode(): Int = super.hashCode()
 
   private implicit def AbstractConvert(array: AbstractTensor): Nd4jTensor = array.asInstanceOf[Nd4jTensor]
 }

--- a/src/main/scala/org/dia/tensors/Nd4jTensor.scala
+++ b/src/main/scala/org/dia/tensors/Nd4jTensor.scala
@@ -172,6 +172,8 @@ class Nd4jTensor(val tensor: INDArray) extends AbstractTensor {
 
   def data: Array[Double] = tensor.data.asDouble()
 
+  def stack(array: AbstractTensor*) : Nd4jTensor = Nd4j.hstack(this.tensor, array)
+
   /**
    * Utility Functions
    */

--- a/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
+++ b/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
@@ -51,15 +51,15 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
     assert(fileCount == 10)
   }
 
-  test("testRepartitionBySubset") {
+  test("testSplitTiles") {
     val Dataset = new SciDataset(netcdfDataset)
     val someRDD = SparkTestConstants.sc.sparkContext.parallelize(0 until 1)
     val keyFunc : SciDataset => Int = sciD => sciD.datasetName.toInt
 
     // sqaure subset
-    LOG.info("Square subset of shape (2,2)")
+    LOG.info("Square subset of shape (80,80)")
     val subSettedRDD = someRDD.map(p => Dataset.setName(p.toString))
-      .splitTiles("data", keyFunc, 2, 2)
+      .splitTiles("data", keyFunc, 80, 80)
     val subsets = subSettedRDD.collect
     for ((ranges, (index, tensor)) <- subsets) {
       assert(Dataset("data")(ranges: _*) == tensor)
@@ -68,7 +68,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
     // rectangle subset
     LOG.info("Rectangle subset")
     val subSettedRDD2 = someRDD.map(p => Dataset.setName(p.toString))
-      .splitTiles("data", keyFunc, 2, 3)
+      .splitTiles("data", keyFunc, 200, 30)
     val subsets2 = subSettedRDD2.collect
     for ((ranges, (index, tensor)) <- subsets2) {
       assert(Dataset("data")(ranges: _*) == tensor)
@@ -77,7 +77,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
     // row subset
     LOG.info("Row subset")
     val subSettedRDD3 = someRDD.map(p => Dataset.setName(p.toString))
-      .splitTiles("data", keyFunc, 1)
+      .splitTiles("data", keyFunc, 100)
     val subsets3 = subSettedRDD3.collect
     for ((ranges, (index, tensor)) <- subsets3) {
       assert(Dataset("data")(ranges: _*) == tensor)
@@ -94,7 +94,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
 
   }
 
-  test("testSplitBySubset") {
+  test("testRepartitionBySpace") {
     /**
      * Create a list of Datasets each with its values incremented
      * by a different amount

--- a/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
+++ b/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
@@ -59,7 +59,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
     // sqaure subset
     LOG.info("Square subset of shape (2,2)")
     val subSettedRDD = someRDD.map(p => Dataset.setName(p.toString))
-      .splitBySubset("data", keyFunc, 2, 2)
+      .splitSubsets("data", keyFunc, 2, 2)
     val subsets = subSettedRDD.collect
     for ((ranges, index, tensor) <- subsets) {
       assert(Dataset("data")()(ranges: _*).copy == tensor)
@@ -68,7 +68,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
     // rectangle subset
     LOG.info("Rectangle subset")
     val subSettedRDD2 = someRDD.map(p => Dataset.setName(p.toString))
-      .splitBySubset("data", keyFunc, 2, 3)
+      .splitSubsets("data", keyFunc, 2, 3)
     val subsets2 = subSettedRDD2.collect
     for ((ranges, index, tensor) <- subsets2) {
       assert(Dataset("data")()(ranges: _*).copy == tensor)
@@ -77,7 +77,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
     // row subset
     LOG.info("Row subset")
     val subSettedRDD3 = someRDD.map(p => Dataset.setName(p.toString))
-      .splitBySubset("data", keyFunc, 1)
+      .splitSubsets("data", keyFunc, 1)
     val subsets3 = subSettedRDD3.collect
     for ((ranges, index, tensor) <- subsets3) {
       assert(Dataset("data")()(ranges: _*).copy == tensor)
@@ -86,7 +86,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
     // col subset
     LOG.info("Col subset")
     val subSettedRDD4 = someRDD.map(p => Dataset.setName(p.toString))
-      .splitBySubset("data", keyFunc, 1)
+      .splitSubsets("data", keyFunc, 1)
     val subsets4 = subSettedRDD4.collect
     for ((ranges, index, tensor) <- subsets3) {
       assert(Dataset("data")()(ranges: _*).copy == tensor)

--- a/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
+++ b/src/test/scala/org/dia/core/SRDDFunctionsTest.scala
@@ -113,7 +113,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
 
     // Join together entire arrays without subsetting
     LOG.info("Testing join of entire array")
-    val spacePartitionedRDD = someRDD.splitBySubsets("data", keyFunc)
+    val spacePartitionedRDD = someRDD.repartitionBySpace("data", keyFunc)
     val spacePartitioned = spacePartitionedRDD.collect
     for((abst, indx) <- spacePartitioned.zipWithIndex) {
       assert(abst.shape().toList == List(lenAlongDimension, 400, 1440))
@@ -127,7 +127,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
 
     // Split into shapes of 200 by 1440
     LOG.info("Testing tile by 200 x 1440")
-    val spacePartitionedRDD2 = someRDD.splitBySubsets("data", keyFunc, 200)
+    val spacePartitionedRDD2 = someRDD.repartitionBySpace("data", keyFunc, 200)
     val spacePartitioned2 = spacePartitionedRDD2.collect.sortBy(p => p.name)
     for((abst, indx) <- spacePartitioned2.zipWithIndex) {
       assert(abst.shape().toList == List(lenAlongDimension, 200, 1440))
@@ -140,7 +140,7 @@ class SRDDFunctionsTest extends FunSuite with BeforeAndAfterEach {
 
     // Split into shapes of 200 by 144
     LOG.info("Testing tile by 200 x 144")
-    val spacePartitionedRDD3 = someRDD.splitBySubsets("data", keyFunc, 200, 144)
+    val spacePartitionedRDD3 = someRDD.repartitionBySpace("data", keyFunc, 200, 144)
     val pattern = "\\[([0-9]+):([0-9]+)\\,([0-9]+):([0-9]+)\\]".r
     val spacePartitioned3 = spacePartitionedRDD3.collect.sortBy(p => {
       val pattern(w, x, y, z) = p.name.slice(13, p.name.length)

--- a/src/test/scala/org/dia/mcc/MCCOpsTest.scala
+++ b/src/test/scala/org/dia/mcc/MCCOpsTest.scala
@@ -74,16 +74,17 @@ class MCCOpsTest extends FunSuite {
       Array(0.0, 0.0, 0.0, 0.0),
       Array(3.0, 0.0, 4.0, 0.0))
 
-    val flattened = array.flatMap(p => p)
+    val flattened = array.flatten
     val tensor: AbstractTensor = new Nd4jTensor(flattened, Array(5, 4))
     val averageColumnsolution = new Nd4jTensor(Array(1.2, 0.6, 1.0, 0.8), Array(1, 4))
     val averageDoubleColumnsSolution = new Nd4jTensor(Array(0.9, 0.9), Array(1, 2))
     val averageRowSolution = new Nd4jTensor(Array(1.0, 1.0, 0.75, 0.0, 1.75), Array(5, 1))
-    val mismatchedDimensionSolution = new Nd4jTensor(Array(0.78), Array(1, 1))
+    val mismatchedDimensionSolution = new Nd4jTensor(Array(0.7777778), Array(1, 1))
 
     val averageColumns = MCCOps.reduceRectangleResolution(tensor, 5, 1, 9999999)
     val averageDoubleColums = MCCOps.reduceRectangleResolution(tensor, 5, 2, 9999999)
     val averageRows = MCCOps.reduceRectangleResolution(tensor, 1, 4, 999999)
+    // need to round to hundredth as answer is rounded to hundredth
     val mismatchedDimension = MCCOps.reduceRectangleResolution(tensor, 3, 3, 99999999)
 
     assert(averageColumns == averageColumnsolution)

--- a/src/test/scala/org/dia/tensors/BasicTensorTest.scala
+++ b/src/test/scala/org/dia/tensors/BasicTensorTest.scala
@@ -68,7 +68,7 @@ class BasicTensorTest extends FunSuite {
   test("filter") {
     logger.info("In filter test ...")
     val dense = Nd4j.create(Array[Double](1, 241, 241, 1), Array(2, 2))
-    val t = Nd4j.create(Array[Double](1, 0, 0, 0), Array(2, 2))
+    val t = Nd4j.create(Array[Double](1, 0, 0, 1), Array(2, 2))
     val Nd4jt1 = new Nd4jTensor(t)
     val Nd4jt2 = new Nd4jTensor(dense).map(p => if (p < 241) p else 0)
     logger.info(t.toString)
@@ -198,7 +198,9 @@ class BasicTensorTest extends FunSuite {
     val cubeTensor = new Nd4jTensor(cube)
     val solutionTensor = new Nd4jTensor(solutionDetrended)
     val detrended = cubeTensor.detrend(0)
-    assert(detrended == solutionTensor)
+    // Need to round to hundredth since the solution array is also rounded to hundredth
+    val roundedDetrend = detrended.map(p => Math.round(p * 100) / 100.0)
+    assert(roundedDetrend == solutionTensor)
   }
 
   test("assign") {


### PR DESCRIPTION
Addresses issue #7 - repartition by space.

sRDDFunctions now has a function called repartitionBySpace.
repartitionBySpace takes an RDD of SciDatasets, a variable name, and a tile shape e.g. (3, 5).
1. First splitTiles() is called.
   It splits the variable into tiles specified by the shape. 
   Each tile is also keyed by the location in the variable array.
   For example the first tile of a 6 x 10 variable array has key (0->3, 0->5), the second (0->3, 5->10), 
   the third (3->6,0->5), the fourth (3->6, 5->10).
   Tiles originating from the same SciDataset also have an index number to belong to on a new axis (e.g. time). The index number is obtained by a user specified function of type (SciDataset => Int).
   Thus the output of split tiles is an RDD of (rangeKey, (newIndex, Tile))
2. Finally stackTiles() is called
   ReduceByKey is called to group together tiles that originated from the same location in their respective arrays.
   For example tile (0->3, 0->5) in SciDataset 1, and tile (0->3, 0->5) in SciDataset 2 will be grouped together.

Once grouped the tiles are then sorted and stacked in that order on the new axis.
For example tiles from range (0->3, 0->5) will be sorted in time order to get a Variable array with dimension (2, 3, 5). The first index corresponds to the tile at time 1, and the second index corresponds to the tile at time 2.

The functions are general, such that variables of any shape can be split into sub-blocks and coalesced.

The result is cubes (or a higher dimensional shape than the original arrays) with the time dimension intact rather than split across the cluster.

This should help with calculations that require multiple runs across the time axis, because it keeps locality along time.

Other changes :
1. The equality method on tensors were updated.
    Tensors of the same implementation should use their defined equality definitions.
    Tensors of different implementations should check equality by comparing the linear array representations.
1. A few tests began to fail due to the solutions having a lower precision then the ones outputted by the test operations. These have been corrected.

Notes :
I'm using the term "stack" to describe this functionality in numpy which is also called stack. http://docs.scipy.org/doc/numpy/reference/generated/numpy.stack.html

A stack function has been implemented on the tensor classes.
The numpy implementation allows you to stack along any dimension.
Right now we only allow stacking on the first dimension.

@kwhitehall @chrismattmann @BrianWilson1 Thoughts?
