### PR TITLE
[SCISPARK Benchmark] Updates to accommodate errors/results found with benchmarks

### DIFF
--- a/src/main/scala/org/dia/core/SRDDFunctions.scala
+++ b/src/main/scala/org/dia/core/SRDDFunctions.scala
@@ -46,13 +46,16 @@ class SRDDFunctions(self: RDD[SciDataset]) extends Serializable {
    * This is a quick fix function that writes to the local filesystem
    * under tmp and the copies it to hdfs.
    * TODO :: Write netcdfFile directly to hdfs rather to local fs and then copying over.
+   *
+   * @param directoryPath The directory to write to. The hdfs path format is HDFS://HOSTNAME:<porn no.>
+   * @param stagingPath The area to stage files on the local filesystem. Default is /tmp/.
    */
-  def writeSRDD(directoryPath : String): Unit = {
+  def writeSRDD(directoryPath : String, stagingPath : String = "/tmp/"): Unit = {
     self.foreach(p => {
-      p.writeToNetCDF(p.datasetName, "/tmp/")
+      p.writeToNetCDF(p.datasetName, stagingPath)
       val conf = new Configuration()
       val fs = FileSystem.get(new URI(directoryPath), conf)
-      FileUtil.copy(new File("/tmp/" + p.datasetName), fs, new Path(directoryPath), true, conf)
+      FileUtil.copy(new File(stagingPath + p.datasetName), fs, new Path(directoryPath), true, conf)
     })
   }
 

--- a/src/main/scala/org/dia/core/SRDDFunctions.scala
+++ b/src/main/scala/org/dia/core/SRDDFunctions.scala
@@ -47,7 +47,7 @@ class SRDDFunctions(self: RDD[SciDataset]) extends Serializable {
    * under tmp and the copies it to hdfs.
    * TODO :: Write netcdfFile directly to hdfs rather to local fs and then copying over.
    *
-   * @param directoryPath The directory to write to. The hdfs path format is HDFS://HOSTNAME:<porn no.>
+   * @param directoryPath The directory to write to. The hdfs path format is HDFS://HOSTNAME:<port no.>
    * @param stagingPath The area to stage files on the local filesystem. Default is /tmp/.
    */
   def writeSRDD(directoryPath : String, stagingPath : String = "/tmp/"): Unit = {

--- a/src/main/scala/org/dia/core/SciDataset.scala
+++ b/src/main/scala/org/dia/core/SciDataset.scala
@@ -201,11 +201,12 @@ class SciDataset(val variables: mutable.HashMap[String, Variable],
    */
   def writeToNetCDF(name: String = datasetName, path: String = ""): Unit = {
     val writer = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3, path + name, null)
+    val globalDimensionMap = mutable.HashMap[String, ucar.nc2.Dimension]()
     val netcdfKeyValue = variables.map {
       case (key, variable) =>
         val dims = new util.ArrayList[ucar.nc2.Dimension]()
         for ((dimName, length) <- variable.dims) {
-          val newDim = writer.addDimension(null, dimName, length)
+          val newDim = globalDimensionMap.getOrElseUpdate(dimName, writer.addDimension(null, dimName, length))
           dims.add(newDim)
         }
         val varT = writer.addVariable(null, key, ucar.ma2.DataType.FLOAT, dims)

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -214,7 +214,7 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
                                  varName: List[String] = Nil,
                                  partitions: Int = defaultPartitions): RDD[SciDataset] = {
 
-    val fs = FileSystem.get(new Configuration())
+    val fs = FileSystem.get(new URI(path), new Configuration())
     val FileStatuses = fs.listStatus(new Path(path))
     val fileNames = FileStatuses.map(p => p.getPath.getName)
     val nameRDD = sparkContext.parallelize(fileNames, partitions)

--- a/src/main/scala/org/dia/core/SciSparkContext.scala
+++ b/src/main/scala/org/dia/core/SciSparkContext.scala
@@ -258,17 +258,17 @@ class SciSparkContext(@transient val sparkContext: SparkContext) {
   }
 
   /**
-    * Constructs an RDD given a URI pointing to an HDFS directory of Netcdf files and a list of variable names.
-    * Note that since the files are read from HDFS, the binaryFiles function is used which is called
-    * from SparkContext.
-    * netcdfWholeDatasets should only be used for reading large subsets of variables or all the
-    * variables in NetCDF Files.
-    *
-    * @param path the path to read from. The format for HDFS directory is : hdfs://HOSTNAME:<port no.>
-    * @param varNames the names of variables to extract. If none are provided, then all variables are reaad.
-    * @param partitions The number of partitions to split the dataset into
-    * @return
-    */
+   * Constructs an RDD given a URI pointing to an HDFS directory of Netcdf files and a list of variable names.
+   * Note that since the files are read from HDFS, the binaryFiles function is used which is called
+   * from SparkContext.
+   * netcdfWholeDatasets should only be used for reading large subsets of variables or all the
+   * variables in NetCDF Files.
+   *
+   * @param path the path to read from. The format for HDFS directory is : hdfs://HOSTNAME:<port no.>
+   * @param varNames the names of variables to extract. If none are provided, then all variables are reaad.
+   * @param partitions The number of partitions to split the dataset into
+   * @return
+   */
   def netcdfWholeDatasets(path: String,
                           varNames: List[String] = Nil,
                           partitions: Int = defaultPartitions): RDD[SciDataset] = {

--- a/src/main/scala/org/dia/loaders/RandomMatrixReader.scala
+++ b/src/main/scala/org/dia/loaders/RandomMatrixReader.scala
@@ -21,6 +21,9 @@ import java.util.Random
 
 import org.nd4j.linalg.factory.Nd4j
 
+import org.dia.core.SciDataset
+import org.dia.tensors.Nd4jTensor
+
 /**
  * Generates random matrices.
  */
@@ -66,6 +69,21 @@ object RandomMatrixReader {
       }
     }
     (ndArray.data.asDouble, ndArray.shape)
+  }
+
+
+  def createRandomSciDataset(name: String,
+                             variables : List[(String, Array[Int])],
+                             attributes : List[(String, String)]): SciDataset = {
+    val SciVars = variables.map({
+      case (filename, shape) =>
+        val nd4jTensor = new Nd4jTensor(Nd4j.rand(shape, filename.hashCode.toLong)) * 300.0
+        val dims = shape.zip(Array("u", "v", "w", "x", "y", "z"))
+          .map({ case (dim, name) => (filename + "_" + name.toString, dim) }).toList
+        (filename, new org.dia.core.Variable(filename, nd4jTensor, dims))
+    })
+
+    new org.dia.core.SciDataset(SciVars, attributes, name)
   }
 
 }

--- a/src/main/scala/org/dia/loaders/RandomMatrixReader.scala
+++ b/src/main/scala/org/dia/loaders/RandomMatrixReader.scala
@@ -22,6 +22,7 @@ import java.util.Random
 import org.nd4j.linalg.factory.Nd4j
 
 import org.dia.core.SciDataset
+import org.dia.core.Variable
 import org.dia.tensors.Nd4jTensor
 
 /**
@@ -80,10 +81,10 @@ object RandomMatrixReader {
         val nd4jTensor = new Nd4jTensor(Nd4j.rand(shape, filename.hashCode.toLong)) * 300.0
         val dims = shape.zip(Array("u", "v", "w", "x", "y", "z"))
           .map({ case (dim, name) => (filename + "_" + name.toString, dim) }).toList
-        (filename, new org.dia.core.Variable(filename, nd4jTensor, dims))
+        (filename, new Variable(filename, nd4jTensor, dims))
     })
 
-    new org.dia.core.SciDataset(SciVars, attributes, name)
+    new SciDataset(SciVars, attributes, name)
   }
 
 }

--- a/src/test/scala/org/dia/core/SciDatasetTest.scala
+++ b/src/test/scala/org/dia/core/SciDatasetTest.scala
@@ -110,4 +110,13 @@ class SciDatasetTest extends FunSuite with BeforeAndAfter{
     assert(newDataset == Dataset)
   }
 
+  test("writeDataset Variables with shared dimension") {
+    val name = Dataset.datasetName
+    val k = Dataset("data")
+    Dataset("newData") = Dataset("data").copy().setName("newData")
+    Dataset.writeToNetCDF()
+    val newDataset = new SciDataset(NetCDFUtils.loadNetCDFDataSet(name))
+    assert(newDataset == Dataset)
+  }
+
 }

--- a/src/test/scala/org/dia/core/SciSparkContextTest.scala
+++ b/src/test/scala/org/dia/core/SciSparkContextTest.scala
@@ -91,6 +91,18 @@ class SciSparkContextTest extends FunSuite with BeforeAndAfter {
     assert(listCount == 2)
   }
 
+  test("netcdfWholeDatasets") {
+    val variable = "data"
+    val variable2 = SparkTestConstants.datasetVariable
+    val randomRDD = sc.netcdfRandomAccessDatasets("src/test/resources/Netcdf/", List(variable))
+    val wholeRDD = sc.netcdfWholeDatasets("src/test/resources/Netcdf/", List(variable))
+
+    val randomList = randomRDD.collect.toList
+    val wholeList = wholeRDD.collect.toList
+
+    assert(randomList == wholeList)
+  }
+
   test("PartitionCount") {
     val variable = "data"
     val variable2 = SparkTestConstants.datasetVariable


### PR DESCRIPTION
I needed to slighlty modify areas of code to better utilize the benchmarks, and avoid errors on the cluster.
Here are the following changes listed in order of commit.
1. In SciDataset.writeToNetcdf, the current implementation assumes that variables will have unique dimension names. However, multiple variables in a netcdf file often (if not always) share the same dimensions and dimension names. Adding the same dimension name to a netcdf file twice, results in an error. For example, when the netcdf writer add's dimension "lat" from variable temp, and again add dimension "lat" it will complain saying that the dimension "lat" is already in the group.
   The fix is to keep a global map to keep track of the dimension objects that have already been added by the writer.
2. The HDFS utils throws the following error when I specified an HDFS Path:
   "Wrong FS: hdfs://HOSTNAME:PORT/user/shared/, expected: file:///"
   The solution is to also pass the URI object when initializing the FileSystem object.
3. Currently we support reading Netcdf files into SciDataset objects by using RandomAccess.
   However if we want to read all the variables in a Netcdf file, then leveraging BinaryFiles to sequentially access the file is much more advantageous. To address this, I included another function called netcdfWholeDatasets(), which leverages BinaryFiles to read the entire file into memory.
4. When writing SciDatasets to HDFS, we first write the netcdf file to the local file system before copying it over. The change to writeHDFS adds a new parameter which specifies the staging directory. By default it is /tmp/
5. Finally I added a function that can be used to randomly generate SciDatastes.

EDIT :
This addresses issue #97 
